### PR TITLE
Add EoP utilities doc

### DIFF
--- a/docs/source/eop-docs.rst
+++ b/docs/source/eop-docs.rst
@@ -1,0 +1,15 @@
+Ends of Prosody: corppa utilities
+#################################
+
+Filter Utility
+--------------
+.. automodule:: corppa.utils.filter
+   :noindex:
+.. Note: not including members for method docs, only top-level script usage
+
+Path Utilities
+--------------
+.. automodule:: corppa.utils.path_utils
+   :members: get_vol_dir, get_stub_dir
+   :noindex:
+

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -17,3 +17,4 @@ documentation for details.
 
    Overview <readme.md>
    code-docs
+   eop-docs

--- a/test/test_poetry_detection/test_core.py
+++ b/test/test_poetry_detection/test_core.py
@@ -240,20 +240,6 @@ class TestExcerpt:
         result = excerpt.to_dict()
         assert result == expected_result
 
-    def test_fieldnames(self):
-        fieldnames = Excerpt.fieldnames()
-        # should match the names of the fields as declared
-        # and in the same order
-        assert fieldnames == [
-            "page_id",
-            "ppa_span_start",
-            "ppa_span_end",
-            "ppa_span_text",
-            "detection_methods",
-            "notes",
-            "excerpt_id"
-        ]
-
     def test_to_csv(self):
         # No optional fields
         excerpt = Excerpt(


### PR DESCRIPTION
**Associated Issue(s):** #233 

### Changes in this PR

- Added new doc for Ends of Prosody utilities documentation
- Added this doc to the docs index so the page would compile via `make html`

### Questions
Below are the questions I have for this draft PR.

- Does the new document contain all the documentation we need?
- This should be a standalone document as opposed to part of the sphinx docs for the package, right? If that's the case, what's the proper way to go about building this standalone doc?