### PR TITLE
Merge exact spans and consolidate different poem ids

### DIFF
--- a/notebooks/explore-merged-excerpts.py
+++ b/notebooks/explore-merged-excerpts.py
@@ -1,0 +1,91 @@
+import marimo
+
+__generated_with = "0.19.11"
+app = marimo.App(width="medium")
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    # Merged excerpts
+
+    Preliminary notebook for reviewing merged excerpts.
+    """)
+    return
+
+
+@app.cell
+def _():
+    import pathlib
+
+    import marimo as mo
+    import polars as pl
+
+    from corppa.config import get_config
+    from corppa.poetry_detection.polars_utils import load_excerpts_df
+
+    return get_config, load_excerpts_df, mo, pathlib, pl
+
+
+@app.cell
+def _(get_config, pathlib):
+    config_opts = get_config()
+
+    data_dir = pathlib.Path(config_opts["compiled_dataset"]["data_dir"])
+    if not data_dir.exists() or not data_dir.is_dir():
+        raise ValueError(
+            f"Data directory {data_dir} not found. "
+            + "\nCheck your configuration file, and remember to use an absolute path for the poem dataset data directory."
+        )
+    else:
+        print(f"Data will be loaded from {data_dir}")
+
+    # Create a dictionary of data files for lookup based on file base name without any extension
+    # so that excerpts data can be .csv or compressed .csv.gz
+    data_paths = {
+        data_file.stem.split(".", 1)[0]: data_file for data_file in data_dir.iterdir()
+    }
+    return (data_paths,)
+
+
+@app.cell
+def _(data_paths, load_excerpts_df, pl):
+    excerpts_df = load_excerpts_df(
+        data_paths["excerpts"],
+        ppa_works_meta=data_paths["ppa_work_metadata"],
+        ref_poems_meta=data_paths["poem_meta"],
+    )
+
+    # identify merged excerpts by presence of merge note
+    merged_ex_df = excerpts_df.filter(pl.col("notes").str.contains("merge"))
+    merged_ex_df
+    return excerpts_df, merged_ex_df
+
+
+@app.cell
+def _():
+    return
+
+
+@app.cell
+def _(excerpts_df, pl):
+    # check for excerpts with multiple poem identifications
+    multi_poem_id_df = excerpts_df.filter(pl.col("alt_poem_ids").list.len().gt(0))
+    multi_poem_id_df
+    return (multi_poem_id_df,)
+
+
+@app.cell
+def _(excerpts_df, merged_ex_df, mo, multi_poem_id_df):
+    # summarize
+    mo.md(
+        f"""
+        {merged_ex_df.height:,} out of {excerpts_df.height:,} total excerpts are merges ({merged_ex_df.height/excerpts_df.height * 100:.2f}%).
+    
+        {multi_poem_id_df.height:,} out of {merged_ex_df.height:,} merged excerpts have multiple poem ids ({multi_poem_id_df.height/merged_ex_df.height * 100:.2f}%)"""
+    )
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/notebooks/explore-merged-excerpts.py
+++ b/notebooks/explore-merged-excerpts.py
@@ -22,9 +22,12 @@ def _():
     import polars as pl
 
     from corppa.config import get_config
-    from corppa.poetry_detection.polars_utils import load_excerpts_df
+    from corppa.poetry_detection.polars_utils import (
+        add_ref_poems_meta,
+        load_excerpts_df,
+    )
 
-    return get_config, load_excerpts_df, mo, pathlib, pl
+    return add_ref_poems_meta, get_config, load_excerpts_df, mo, pathlib, pl
 
 
 @app.cell
@@ -81,9 +84,53 @@ def _(excerpts_df, merged_ex_df, mo, multi_poem_id_df):
     mo.md(
         f"""
         {merged_ex_df.height:,} out of {excerpts_df.height:,} total excerpts are merges ({merged_ex_df.height/excerpts_df.height * 100:.2f}%).
-    
+
         {multi_poem_id_df.height:,} out of {merged_ex_df.height:,} merged excerpts have multiple poem ids ({multi_poem_id_df.height/merged_ex_df.height * 100:.2f}%)"""
     )
+    return
+
+
+@app.cell
+def _(add_ref_poems_meta, data_paths, multi_poem_id_df, pl):
+    # check what poem ids are getting matched / collapsed
+    poem_pairs_df = (
+        multi_poem_id_df.select(
+            "poem_id",
+            "alt_poem_ids",
+            "poem_author",
+            "poem_title",
+        )
+        .explode("alt_poem_ids")
+        .group_by("poem_id", "alt_poem_ids")
+        .agg(
+            pl.len().alias("count"),
+            pl.first("poem_author", "poem_title"),
+        )
+        .with_columns(
+            alt_poem_id=pl.col("alt_poem_ids"),  # rename to singular
+            alt_ref_corpus=pl.when(pl.col("alt_poem_ids").str.starts_with("Z"))
+            .then(pl.lit("chadwyck-healey"))
+            .otherwise(pl.lit("internet_poems")),
+        )
+        .drop("alt_poem_ids")
+    )
+    poem_pairs_df = add_ref_poems_meta(
+        poem_pairs_df,
+        data_paths["poem_meta"],
+        "alt_poem_id",
+        "alt_ref_corpus",
+        suffix="_alt",
+    )
+
+    poem_pairs_df.select(
+        "poem_id",
+        "alt_poem_id",
+        "count",
+        "poem_author",
+        "poem_title",
+        "poem_author_alt",
+        "poem_title_alt",
+    ).sort("count", descending=True)
     return
 
 

--- a/sample_config.yml
+++ b/sample_config.yml
@@ -11,7 +11,7 @@
 compiled_dataset:
   # NOTE: currently requires an absolute path, since jupyter
   # notebooks will try to load relative to the notebook
-  output_data_dir: "/path/to/ppa-found-poems/data/"
+  data_dir: "/path/to/ppa-found-poems/data/"
 
 # paths to reference corpora metadata and text
 reference_corpora:
@@ -35,4 +35,4 @@ reference_corpora:
   other:
     # Provide a URL or local path to "Other Poems" metadata
     # Use a URL if you want to pull directly from google sheets as CSV or
-    metadata_path: "https://docs.google.com/spreadsheets/d/..." or "/path/to/other.csv"
+    metadata_path: "https://docs.google.com/spreadsheets/d/..."  # or "/path/to/other.csv"

--- a/src/corppa/poetry_detection/compile_dataset.py
+++ b/src/corppa/poetry_detection/compile_dataset.py
@@ -55,12 +55,10 @@ def load_compilation_config():
 
     # output directory
     try:
-        output_data_dir = pathlib.Path(
-            config_opts["compiled_dataset"]["output_data_dir"]
-        )
+        output_data_dir = pathlib.Path(config_opts["compiled_dataset"]["data_dir"])
     except KeyError as err:
         raise ValueError(
-            "Configuration error: config file requires `compiled_dataset.output_data_dir` path"
+            "Configuration error: config file requires `compiled_dataset.data_dir` path"
         ) from err
     if not output_data_dir.exists():
         raise ValueError(
@@ -160,6 +158,11 @@ def compress_file(uncompressed_file, compressed_file):
 
 def main():
     parser = argparse.ArgumentParser(description="Compile PPA found-poems dataset")
+    parser.add_argument(
+        "--compress-excerpts",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+    )
     # add an argument group to allow easily specifying specific steps
     step_arg_group = parser.add_argument_group(
         "Step",
@@ -191,14 +194,15 @@ def main():
         # merge into a single uncompressed csv
         # (polars doesn't currently support writing directly to a csv.gz)
         merge_excerpt_files(excerpt_sources, compile_opts["compiled_excerpt_file"])
-        # compress the resulting file
-        print(
-            f"Compressing excerpt data... ({compile_opts['compiled_excerpt_file']} → {compile_opts['compressed_excerpt_file']})"
-        )
-        compress_file(
-            compile_opts["compiled_excerpt_file"],
-            compile_opts["compressed_excerpt_file"],
-        )
+        # compress the resulting file if requested
+        if args.compress_excerpts:
+            print(
+                f"Compressing excerpt data... ({compile_opts['compiled_excerpt_file']} → {compile_opts['compressed_excerpt_file']})"
+            )
+            compress_file(
+                compile_opts["compiled_excerpt_file"],
+                compile_opts["compressed_excerpt_file"],
+            )
 
     if compilation_steps is None or "poem_metadata" in compilation_steps:
         print("\n## Compiling reference corpora metadata")

--- a/src/corppa/poetry_detection/compile_dataset.py
+++ b/src/corppa/poetry_detection/compile_dataset.py
@@ -61,7 +61,7 @@ def load_compilation_config():
     except KeyError as err:
         raise ValueError(
             "Configuration error: config file requires `compiled_dataset.output_data_dir` path"
-        )
+        ) from err
     if not output_data_dir.exists():
         raise ValueError(
             f"Configuration error: compiled dataset path {output_data_dir} does not exist"

--- a/src/corppa/poetry_detection/core.py
+++ b/src/corppa/poetry_detection/core.py
@@ -158,7 +158,7 @@ class Excerpt:
                 f"PPA span's start index {self.ppa_span_start} must be less than its end index {self.ppa_span_end}"
             )
 
-        # Check that dectection method set is not empty
+        # Check that detection method set is not empty
         if not self.detection_methods:
             raise ValueError("Must specify at least one detection method")
 
@@ -347,7 +347,7 @@ class LabeledExcerpt(Excerpt):
         # Check that identification method set is not empty
         if not self.identification_methods:
             raise ValueError("Must specify at least one identification method")
-        # Check that both reference span indicies are set or unset
+        # Check that both reference span indices are set or unset
         if (self.ref_span_start is None) ^ (self.ref_span_end is None):
             raise ValueError("Reference span's start and end index must both be set")
         # Check reference span indices if set

--- a/src/corppa/poetry_detection/core.py
+++ b/src/corppa/poetry_detection/core.py
@@ -105,7 +105,8 @@ def field_real_type(field_type) -> type:
     # if Optional or Union, return the first non-none type
     ftypes = get_args(field_type)
     if ftypes:
-        return [arg for arg in ftypes if arg != types.NoneType][0]
+        # union type could be another annotation, so return field type
+        return field_real_type([arg for arg in ftypes if arg != types.NoneType][0])
 
     # if we get here, this is an input we can't handle
     raise TypeError(f"Cannot determine real type for '{field_type}'")
@@ -128,6 +129,9 @@ def input_to_set(input_val: list | str | set) -> set:
             return set(input_val.split(MULTIVAL_DELIMITER))
         case set():
             return input_val
+        # None is possible for optional set fields
+        case None:
+            return None
         case _:
             raise ValueError(f"Unexpected value type '{type(input_val).__name__}'")
 
@@ -254,7 +258,7 @@ class Excerpt:
         set_fields = [k for k, v in cls_field_types.items() if v is set]
         for field_name in set_fields:
             try:
-                input_args[field_name] = input_to_set(input_args[field_name])
+                input_args[field_name] = input_to_set(input_args.get(field_name))
             except ValueError as err:
                 raise ValueError(f"{err} for {field_name}")
 
@@ -337,6 +341,7 @@ class LabeledExcerpt(Excerpt):
     ref_span_start: Optional[int] = None
     ref_span_end: Optional[int] = None
     ref_span_text: Optional[str] = None
+    alt_poem_ids: Optional[set[str]] = None
 
     # Identification methods
     identification_methods: set[str]

--- a/src/corppa/poetry_detection/merge_excerpts.py
+++ b/src/corppa/poetry_detection/merge_excerpts.py
@@ -18,9 +18,11 @@ Merging logic is as follows:
   combination of `page_id`, `ppa_span_start`, and `ppa_span_end`)
   even when poem identifications differ, and combined as follows:
 
-     - Excerpts are sorted by `poem_id`, and `ref_span_start` with nulls last,
-       and the reference information is taken from the first excerpt (`poem_id`,
-       `ref_span_start`, `ref_span_end`, `ref_span_text`, `ref_corpus`).
+     - Excerpts are sorted by `poem_id`, `ref_span_start`, and passim
+       match length with nulls last and longest passim match first.
+       Reference information (`poem_id`, `ref_span_start`, `ref_span_end`, 
+       `ref_span_text`, `ref_corpus`) is taken from the first excerpt in 
+       the group.
      - When merged excerpts have different poem identifications, all unique
        poem ids after the first are collected into `alt_poem_ids`
      - The `detection_methods` and `identification_methods` fields are combined
@@ -35,7 +37,10 @@ labeled_excerpts.csv -o merged_excerpts.csv
 
 Limitations:
 
-- Currently supports CSV input and output only
+- Merge logic collapses different poem ids that may not correspond;
+  they may be subsets of the same poem, different editions, or entirely
+  different poems.
+- Currently supports CSV input and output only.
 
 """
 

--- a/src/corppa/poetry_detection/merge_excerpts.py
+++ b/src/corppa/poetry_detection/merge_excerpts.py
@@ -105,7 +105,8 @@ def merge_excerpts(
     )
 
     # sort by page then poem id, with nulls last, to ensure we select
-    # a non-null poem id and reference data
+    # a non-null poem id and reference data;
+    # extract passim match length and sort longest passim matches first
     merge_groups = (
         merge_candidates.with_columns(
             # extract passim match length so we can prioritize longer matches

--- a/src/corppa/poetry_detection/merge_excerpts.py
+++ b/src/corppa/poetry_detection/merge_excerpts.py
@@ -139,9 +139,11 @@ def merge_excerpts(
         .drop("group_size")
     )
 
-    merge_groups = merge_candidates.group_by(
-        ["page_id", "ppa_span_start", "ppa_span_end"]
-    )
+    # sort by page then poem id, with nulls last, to ensure we select
+    # a non-null poem id and reference data
+    merge_groups = merge_candidates.sort(
+        "page_id", "poem_id", "ref_span_start", nulls_last=True
+    ).group_by(["page_id", "ppa_span_start", "ppa_span_end"], maintain_order=True)
     num_merge_groups = merge_groups.len().height
     if verbose:
         print(
@@ -157,20 +159,27 @@ def merge_excerpts(
             # combine notes but don't repeat duplicate info (like passim char match count)
             pl.col("notes").explode().unique().sort().str.join("; "),
             # construct merged excerpt id manually; c= prefix for combined
-            # (although strictly speaking should only be  if > 1 detection method)
+            # (although strictly speaking should only be if > 1 detection method)
             pl.concat_str(
                 pl.lit("c@"),
                 pl.col("ppa_span_start").first(),
                 pl.lit(":"),
                 pl.col("ppa_span_end").first(),
             ).alias("excerpt_id"),
-            # TODO: better to pick first non-null and put alternates in a separate field?
-            pl.col("poem_id").explode().unique().sort().str.join("; "),
-            pl.col("ref_corpus").explode().unique().sort().str.join("; "),
+            # pick the first poem id (relies on previous sorting)
+            pl.col("poem_id").explode().unique().first(),
+            # and store all others in alt poem ids field
+            pl.col("poem_id")
+            .explode()
+            .unique()
+            .drop_nulls()
+            .slice(1)
+            .alias("alt_poem_ids"),
+            pl.col("ref_corpus").explode().first(),
             # use first reference span and text so numbers are useful; ignore nulls
-            pl.col("ref_span_start").drop_nulls().first(),
-            pl.col("ref_span_end").drop_nulls().first(),
-            pl.col("ref_span_text").drop_nulls().first(),
+            pl.col("ref_span_start").first(),
+            pl.col("ref_span_end").first(),
+            pl.col("ref_span_text").first(),
             # combine unique list of id methods
             pl.col("identification_methods")
             .explode()
@@ -182,19 +191,24 @@ def merge_excerpts(
             pl.len().alias("group_size"),  # count number in the group
         )
         .with_columns(
-            # add
             notes=pl.concat_str(
                 pl.col("notes"),
                 pl.lit("; merge: ppa exact span, "),
                 pl.col("group_size"),
                 pl.lit(" excerpts"),
             ),
+            # if alt poem ids is empty, replace with None
+            alt_poem_ids=pl.when(pl.col("alt_poem_ids").list.len() > 0)
+            .then(pl.col("alt_poem_ids"))
+            .otherwise(pl.lit(None)),
         )
         .drop("group_size")  # drop group size column
     )
 
     if verbose:
-        multi_id = merged_output_df.filter(pl.col("poem_id").str.contains(";")).height
+        multi_id = merged_output_df.filter(
+            pl.col("alt_poem_ids").list.len().gt(0)
+        ).height
         print(
             f"{merged_output_df.height:,} merged excerpts; {multi_id:,} with multiple poem ids."
         )
@@ -250,6 +264,7 @@ def merge_excerpt_files(input_files, output_file):
         identification_methods=pl.col("identification_methods")
         .list.sort()
         .list.join(MULTIVAL_DELIMITER),
+        alt_poem_ids=pl.col("alt_poem_ids").list.join(MULTIVAL_DELIMITER),
     )
 
     labeled_excerpts = excerpts.filter(pl.col("poem_id").is_not_null())

--- a/src/corppa/poetry_detection/merge_excerpts.py
+++ b/src/corppa/poetry_detection/merge_excerpts.py
@@ -148,7 +148,7 @@ def merge_excerpts(
             f"Identified {merge_candidates.height:,} merge candidates in {num_merge_groups:,} groups."
         )
 
-    merged_excerpts = (
+    merged_output_df = (
         merge_groups.agg(
             pl.first("ppa_span_text"),  # should match exactly
             pl.col("detection_methods")
@@ -157,12 +157,14 @@ def merge_excerpts(
             # combine notes but don't repeat duplicate info (like passim char match count)
             pl.col("notes").explode().unique().sort().str.join("; "),
             # construct merged excerpt id manually; c= prefix for combined
+            # (although strictly speaking should only be  if > 1 detection method)
             pl.concat_str(
                 pl.lit("c@"),
                 pl.col("ppa_span_start").first(),
                 pl.lit(":"),
                 pl.col("ppa_span_end").first(),
             ).alias("excerpt_id"),
+            # TODO: better to pick first non-null and put alternates in a separate field?
             pl.col("poem_id").explode().unique().sort().str.join("; "),
             pl.col("ref_corpus").explode().unique().sort().str.join("; "),
             # use first reference span and text so numbers are useful; ignore nulls
@@ -183,23 +185,24 @@ def merge_excerpts(
             # add
             notes=pl.concat_str(
                 pl.col("notes"),
-                pl.lit("; merge: ppa exact span "),
+                pl.lit("; merge: ppa exact span, "),
                 pl.col("group_size"),
-                pl.lit("excerpts"),
+                pl.lit(" excerpts"),
             ),
         )
         .drop("group_size")  # drop group size column
     )
 
     if verbose:
-        multi_id = merged_excerpts.filter(pl.col("poem_id").str.contains(";")).height
+        multi_id = merged_output_df.filter(pl.col("poem_id").str.contains(";")).height
         print(
-            f"{merged_excerpts.height:,} merged excerpts; {multi_id:,} with multiple poem ids."
+            f"{merged_output_df.height:,} merged excerpts; {multi_id:,} with multiple poem ids."
         )
 
-    # add the merged records to the output
-    output_df.extend(merged_excerpts)
-    return output_df
+    # combined merged records with the output
+    # use a diagonal concat instead of vstack/extend
+    # to avoid having to reconcile columns first
+    return pl.concat([output_df, merged_output_df], how="diagonal")
 
 
 def merge_excerpt_files(input_files, output_file):

--- a/src/corppa/poetry_detection/merge_excerpts.py
+++ b/src/corppa/poetry_detection/merge_excerpts.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
-# Copyright (c) 2024-2025, Center for Digital Humanities, Princeton University
+# Copyright (c) 2024-2026, Center for Digital Humanities, Princeton University
 # SPDX-License-Identifier: Apache-2.0
 
 """
-This script merges labeled and unlabeled poem excerpts, combining
-notes for any merged excerpts, and merging duplicate poem identifications
-in simple cases.
+This script and associated method merges labeled and unlabeled poem excerpts 
+with matching spans in the PPA page text.
 
 It takes two or more input files of excerpt data (labeled or unlabeled) in CSV format,
 merges any excerpts that can be combined, and outputs a CSV with the updated excerpt data.
@@ -15,19 +14,19 @@ the output will likely be a mix of labeled and unlabeled excerpts.
 
 Merging logic is as follows:
 
-- Excerpts are grouped on the combination of page id and excerpt id,
-  and then merged if all reference fields match exactly, or where
-  reference fields are present in one excerpt and unset in the other.
+- Excerpts are grouped based on exact span match in PPA text (i.e., the
+  combination of `page_id`, `ppa_span_start`, and `ppa_span_end`)
+  even when poem identifications differ, and combined as follows:
 
-    - If the same excerpt has different labels (different `poem_id` values), both
-      labeled excerpts will be included in the output
-    - If the same excerpt has duplicate labels (i.e., the same `poem_id` from two
-      different identification methods), they will be merged
-      into a single labeled excerpt; the `identification_methods` in the
-      resulting labeled excerpt will be the union of methods in the merged excerpts
-
-- When merging excerpts where both records have notes, notes content
-  will be combined.
+     - Excerpts are sorted by `poem_id`, and `ref_span_start` with nulls last,
+       and the reference information is taken from the first excerpt (`poem_id`,
+       `ref_span_start`, `ref_span_end`, `ref_span_text`, `ref_corpus`).
+     - When merged excerpts have different poem identifications, all unique
+       poem ids after the first are collected into `alt_poem_ids`
+     - The `detection_methods` and `identification_methods` fields are combined
+       to the unique set of methods used in the merged excerpts.
+     - The `notes` field is combined with the set of all unique content from 
+       notes in merged excerpts with an additional note about the merge.
 
 Example usage: ::
 
@@ -36,18 +35,11 @@ labeled_excerpts.csv -o merged_excerpts.csv
 
 Limitations:
 
-- Labeled excerpts with the same poem_id but different reference data
-  will not be merged; supporting multiple identification methods that output
-  span information will likely require more sophisticated merge logic
-- CSV input and output only (JSONL may be added in future)
-- Notes are currently merged only with the first matching excerpt; if an 
-  unlabeled excerpt with notes has multiple labels, only the first match
-  will have combined notes
+- Currently supports CSV input and output only
 
 """
 
 import argparse
-import itertools
 import pathlib
 import sys
 
@@ -55,38 +47,6 @@ import polars as pl
 
 from corppa.poetry_detection.core import MULTIVAL_DELIMITER
 from corppa.poetry_detection.polars_utils import load_excerpts_df, standardize_dataframe
-
-
-def combine_duplicate_methods_notes(repeats_df: pl.DataFrame) -> pl.DataFrame:
-    """
-    Takes a dataframe of repeated excerpts with duplicate information,
-    and updates all rows with the combined set of unique
-    detection_methods, identification_methods, and notes. Returns the
-    updated dataframe with the combined fields.
-
-    Intended for use on grouped excerpts in :meth:`merge_excerpts`.
-    """
-    # get detection methods as a list of lists, use itertools to unwrap
-    # the lists; consume the itertools generator and use set to uniquify,
-    # then convert back to list to put back in the polars dataframe
-    detect_methods = repeats_df["detection_methods"].drop_nulls().to_list()
-    combined_detect_methods = list(set(itertools.chain.from_iterable(detect_methods)))
-    # id methods could be all unset even in a group
-    id_methods = repeats_df["identification_methods"].drop_nulls().to_list()
-    combined_id_methods = None
-    if id_methods:
-        combined_id_methods = list(set(itertools.chain.from_iterable(id_methods)))
-    # join all unique notes within this group; don't repeat notes
-    # preserve order (unlabeled excerpt notes first)
-    unique_notes = repeats_df["notes"].drop_nulls().unique(maintain_order=True)
-    combined_notes = "\n".join([n for n in unique_notes if n.strip()])
-
-    repeats_df = repeats_df.with_columns(
-        detection_methods=pl.lit(combined_detect_methods),
-        identification_methods=pl.lit(combined_id_methods),
-        notes=pl.lit(combined_notes),
-    )
-    return repeats_df
 
 
 def merge_excerpts(
@@ -141,9 +101,21 @@ def merge_excerpts(
 
     # sort by page then poem id, with nulls last, to ensure we select
     # a non-null poem id and reference data
-    merge_groups = merge_candidates.sort(
-        "page_id", "poem_id", "ref_span_start", nulls_last=True
-    ).group_by(["page_id", "ppa_span_start", "ppa_span_end"], maintain_order=True)
+    merge_groups = (
+        merge_candidates.with_columns(
+            # extract passim match length so we can prioritize longer matches
+            passim_match_len=pl.col("notes").str.extract(r"passim: (\d+) char matches")
+        )
+        .sort(
+            "page_id",
+            "passim_match_len",
+            "poem_id",
+            "ref_span_start",
+            nulls_last=True,
+            descending=[False, True, False, False],  # sort longest passim matches first
+        )
+        .group_by(["page_id", "ppa_span_start", "ppa_span_end"], maintain_order=True)
+    )
     num_merge_groups = merge_groups.len().height
     if verbose:
         print(
@@ -185,9 +157,6 @@ def merge_excerpts(
             .explode()
             .unique()
             .drop_nulls(),  # combine in a single list, no repeats, ignore nulls (not identified before merging)
-            # OMIT: we don't have these until we join
-            # pl.col("poem_author").explode().unique().sort().str.join("; "),
-            # pl.col("poem_title").explode().unique().sort().str.join("; "),
             pl.len().alias("group_size"),  # count number in the group
         )
         .with_columns(

--- a/src/corppa/poetry_detection/merge_excerpts.py
+++ b/src/corppa/poetry_detection/merge_excerpts.py
@@ -52,7 +52,6 @@ import pathlib
 import sys
 
 import polars as pl
-from tqdm import tqdm
 
 from corppa.poetry_detection.core import MULTIVAL_DELIMITER
 from corppa.poetry_detection.polars_utils import load_excerpts_df, standardize_dataframe
@@ -119,11 +118,14 @@ def merge_excerpts(
     # group by page id and excerpt id to get potential matches
     # use aggregation to get the count of excerpts in each group,
     # then split input dataframe into singletons and merge candidates
-    grouped = df.group_by(["page_id", "excerpt_id"]).agg(pl.len().alias("group_size"))
+    # NOTE: span start/end to merge across systems, because excerpt id includes detection method
+    grouped = df.group_by(["page_id", "ppa_span_start", "ppa_span_end"]).agg(
+        pl.len().alias("group_size")
+    )
     # any excerpts with group size one will not be merged;
     # add to output df and don't process further
     output_df = (
-        df.join(grouped, on=["page_id", "excerpt_id"])
+        df.join(grouped, on=["page_id", "ppa_span_start", "ppa_span_end"])
         .filter(pl.col("group_size").eq(1))
         .drop("group_size")
     )
@@ -132,70 +134,71 @@ def merge_excerpts(
 
     # any excerpts with group size > 1 are candidates for merging
     merge_candidates = (
-        df.join(grouped, on=["page_id", "excerpt_id"])
+        df.join(grouped, on=["page_id", "ppa_span_start", "ppa_span_end"])
         .filter(pl.col("group_size").gt(1))
         .drop("group_size")
     )
 
-    merge_groups = merge_candidates.group_by(["page_id", "excerpt_id"])
+    merge_groups = merge_candidates.group_by(
+        ["page_id", "ppa_span_start", "ppa_span_end"]
+    )
     num_merge_groups = merge_groups.len().height
     if verbose:
         print(
-            f"Identified {merge_candidates.height:,} merge candidates in {num_merge_groups:,} groups.\n"
+            f"Identified {merge_candidates.height:,} merge candidates in {num_merge_groups:,} groups."
         )
 
-    progress_groups = tqdm(
-        merge_groups,
-        total=num_merge_groups,
-        desc="Merging...",
-        disable=disable_progress,
+    merged_excerpts = (
+        merge_groups.agg(
+            pl.first("ppa_span_text"),  # should match exactly
+            pl.col("detection_methods")
+            .explode()
+            .unique(),  # combine in a single list, no repeats
+            # combine notes but don't repeat duplicate info (like passim char match count)
+            pl.col("notes").explode().unique().sort().str.join("; "),
+            # construct merged excerpt id manually; c= prefix for combined
+            pl.concat_str(
+                pl.lit("c@"),
+                pl.col("ppa_span_start").first(),
+                pl.lit(":"),
+                pl.col("ppa_span_end").first(),
+            ).alias("excerpt_id"),
+            pl.col("poem_id").explode().unique().sort().str.join("; "),
+            pl.col("ref_corpus").explode().unique().sort().str.join("; "),
+            # use first reference span and text so numbers are useful; ignore nulls
+            pl.col("ref_span_start").drop_nulls().first(),
+            pl.col("ref_span_end").drop_nulls().first(),
+            pl.col("ref_span_text").drop_nulls().first(),
+            # combine unique list of id methods
+            pl.col("identification_methods")
+            .explode()
+            .unique()
+            .drop_nulls(),  # combine in a single list, no repeats, ignore nulls (not identified before merging)
+            # OMIT: we don't have these until we join
+            # pl.col("poem_author").explode().unique().sort().str.join("; "),
+            # pl.col("poem_title").explode().unique().sort().str.join("; "),
+            pl.len().alias("group_size"),  # count number in the group
+        )
+        .with_columns(
+            # add
+            notes=pl.concat_str(
+                pl.col("notes"),
+                pl.lit("; merge: ppa exact span "),
+                pl.col("group_size"),
+                pl.lit("excerpts"),
+            ),
+        )
+        .drop("group_size")  # drop group size column
     )
-    merge_count = 0
-    for group, data in progress_groups:
-        # group is a tuple of values for page id, excerpt id, poem id
-        # data is a df of the grouped rows for this set
 
-        # sort so any empty values for optional reference fields are first,
-        # then fill values backward - i.e., treat nulls as duplicates,
-        # but keep unlabeled excerpts first
-        data = data.sort(
-            "poem_id",
-            "ref_corpus",
-            "ref_span_start",
-            "ref_span_end",
-            "ref_span_text",
-            nulls_last=False,
-        ).select(pl.all().backward_fill())
+    if verbose:
+        multi_id = merged_excerpts.filter(pl.col("poem_id").str.contains(";")).height
+        print(
+            f"{merged_excerpts.height:,} merged excerpts; {multi_id:,} with multiple poem ids."
+        )
 
-        # in case this set of excerpts has multiple different poem ids
-        # which should be merged with each other, group again on poem id
-        for poem_group, poem_data in data.group_by(["poem_id"]):
-            # group of 1 : no merge, add to the output
-            if poem_data.height == 1:
-                output_df.extend(poem_data)
-            # otherwise, look for repeats
-            else:
-                # combine if everything is the same but methods, and notes
-                # (other values must either be the same or don't conflict because they were unset)
-                repeat_counts = poem_data.with_columns(
-                    duplicate=poem_data.drop(
-                        "detection_methods", "identification_methods", "notes"
-                    ).is_duplicated()
-                )
-                # repeats will be consolidated
-                repeats = repeat_counts.filter(pl.col("duplicate")).drop("duplicate")
-                # any non-repeats should be included in output as-is
-                output_df.extend(
-                    repeat_counts.filter(~pl.col("duplicate")).drop("duplicate")
-                )
-
-                if not repeats.is_empty():
-                    repeats = combine_duplicate_methods_notes(repeats)
-                    # add one copy of the consolidated information to the merge df
-                    output_df.extend(repeats[:1])
-                    merge_count += 1
-                    progress_groups.set_postfix_str(f"Merged {merge_count:,}")
-
+    # add the merged records to the output
+    output_df.extend(merged_excerpts)
     return output_df
 
 

--- a/src/corppa/poetry_detection/polars_utils.py
+++ b/src/corppa/poetry_detection/polars_utils.py
@@ -126,13 +126,17 @@ def load_meta_df(file: pathlib.Path, fields_table: dict[str, str]) -> pl.DataFra
 def add_ref_poems_meta(
     excerpts_df: pl.DataFrame,
     ref_poem_meta: pathlib.Path,
+    poem_id_field: str = "poem_id",
+    ref_corpus_field: str = "ref_corpus",
+    suffix: str | None = None,
 ) -> pl.DataFrame:
     """
     Combines found poem excerpt data (:class:`polars.DataFrame`) with reference
     poem metadata (``CSV``, possibly compressed) and returns the resulting
-    ``DataFrame``.
+    ``DataFrame``.  To join on alternate poem id or reference corpus fields
+    in the excerpt data, specify the field names.
     """
-    join_fields = ["poem_id", "ref_corpus"]
+    join_fields = [poem_id_field, ref_corpus_field]
     # Check for required fields
     missing_fields = set(join_fields) - set(excerpts_df.columns)
     if missing_fields:
@@ -141,7 +145,16 @@ def add_ref_poems_meta(
             f"Input DataFrame missing the following required fields: {missing_str}"
         )
     poems_meta_df = load_meta_df(ref_poem_meta, POEM_FIELDS)
-    return excerpts_df.join(poems_meta_df, on=join_fields, how="left")
+    optional_args = {}
+    if suffix is not None:
+        optional_args["suffix"] = suffix
+    return excerpts_df.join(
+        poems_meta_df,
+        left_on=join_fields,
+        right_on=["poem_id", "ref_corpus"],
+        how="left",
+        **optional_args,  # type: ignore[arg-type]
+    )
 
 
 def load_excerpts_df(

--- a/src/corppa/poetry_detection/polars_utils.py
+++ b/src/corppa/poetry_detection/polars_utils.py
@@ -134,7 +134,8 @@ def add_ref_poems_meta(
     Combines found poem excerpt data (:class:`polars.DataFrame`) with reference
     poem metadata (``CSV``, possibly compressed) and returns the resulting
     ``DataFrame``.  To join on alternate poem id or reference corpus fields
-    in the excerpt data, specify the field names.
+    in the excerpt data (e.g., on `alt_poem_ids`), specify the field names,
+    and optionally specify a custom suffix when combining multiple poems.
     """
     join_fields = [poem_id_field, ref_corpus_field]
     # Check for required fields

--- a/src/corppa/poetry_detection/polars_utils.py
+++ b/src/corppa/poetry_detection/polars_utils.py
@@ -25,6 +25,7 @@ FIELD_TYPES = LabeledExcerpt.field_types()
 # override set types with list, since Polars does not have a set type
 FIELD_TYPES["detection_methods"] = pl.List
 FIELD_TYPES["identification_methods"] = pl.List
+FIELD_TYPES["alt_poem_ids"] = pl.List
 
 #: Table of included PPA work-level field names and their names for use downstream
 PPA_FIELDS = {
@@ -61,6 +62,7 @@ def fix_data_types(df):
     """
     # Get expected field types for columns that match Labeled/Excerpt fields
     df_types = {column: FIELD_TYPES.get(column) for column in df.columns}
+    print(df_types)
     for c, ctype in df_types.items():
         # For list (set) types, split strings on multival delimiter to convert to list
         if ctype is pl.List:

--- a/tests/test_poetry_detection/test_core.py
+++ b/tests/test_poetry_detection/test_core.py
@@ -643,6 +643,7 @@ class TestLabeledExcerpt:
             "ref_span_start",
             "ref_span_end",
             "ref_span_text",
+            "alt_poem_ids",
             "identification_methods",
         ]
 
@@ -665,6 +666,7 @@ class TestLabeledExcerpt:
                 "ref_span_end": int,
                 "ref_span_text": str,
                 "identification_methods": set,
+                "alt_poem_ids": set,
             }
         )
 

--- a/tests/test_poetry_detection/test_merge_excerpts.py
+++ b/tests/test_poetry_detection/test_merge_excerpts.py
@@ -104,14 +104,15 @@ def test_merge_excerpts_1ex_2labels(capsys):
 
     # id methods should be combined
     merged_excerpt.identification_methods == excerpt1_label1.identification_methods & excerpt1_label2.identification_methods
-    # multiple poem id currently combined in one field  (TODO: alt poem id field?)
-    assert merged_excerpt.poem_id == "; ".join(
-        [excerpt1_label1.poem_id, excerpt1_label2.poem_id]
-    )
+    # first poem id is selected as primary
+    assert merged_excerpt.poem_id == excerpt1_label1.poem_id
+    # alternate poem ids collected in a separate field
+    assert merged_excerpt.alt_poem_ids == {excerpt1_label2.poem_id}
+
     # all other fields should be unchanged
     for field in LabeledExcerpt.fieldnames():
         # all other fields should have the same content in the merged excerpt
-        if field not in ["notes", "poem_id", "identification_methods"]:
+        if field not in ["notes", "poem_id", "identification_methods", "alt_poem_ids"]:
             assert getattr(merged_excerpt, field) == getattr(excerpt1_label1, field)
 
 
@@ -198,13 +199,13 @@ def test_merge_excerpts_multiple_diff_labels(capsys):
     # identification methods should be combined
     merged_excerpt.identification_methods == excerpt1_label1.identification_methods & excerpt1_label2.identification_methods
 
-    # multiple poem id currently combined in one field  (NOTE: update if we add alt poem id field)
-    assert merged_excerpt.poem_id == "; ".join(
-        [excerpt1_label1.poem_id, excerpt1_label2.poem_id]
-    )
+    # first poem id chosen as primary; others collected as alternate
+    assert merged_excerpt.poem_id == excerpt1_label1.poem_id
+    assert merged_excerpt.alt_poem_ids == {excerpt1_label2.poem_id}
+
     for field in LabeledExcerpt.fieldnames():
         # all other fields should have the same content in the merged excerpt
-        if field not in ["notes", "poem_id", "identification_methods"]:
+        if field not in ["notes", "poem_id", "identification_methods", "alt_poem_ids"]:
             assert getattr(merged_excerpt, field) == getattr(excerpt1_label1, field)
 
 
@@ -237,9 +238,10 @@ def test_merge_different_labels():
     # distinct poem ids combined when span matches exactly
     merged = merge_excerpts(df)
     assert len(merged) == 1
-    assert merged.row(0, named=True)["poem_id"] == "; ".join(
-        [alt_poem_id, excerpt1_label1.poem_id]
-    )
+    merged_result = merged.row(0, named=True)
+    # based on current sort logic, alt poem id will be chosen as primary poem id
+    assert merged_result["poem_id"] == alt_poem_id
+    assert merged_result["alt_poem_ids"] == [excerpt1_label1.poem_id]
 
 
 # revise to merge labeled + unlabeled excerpts
@@ -292,9 +294,9 @@ def test_merge_unlabeled_labeled_excerpts():
         expected_merge_note,
     ]:
         assert note in merged_excerpt["notes"]
-    assert merged_excerpt["poem_id"] == "; ".join(
-        [excerpt1_label1.poem_id, excerpt1_label2.poem_id]
-    )
+
+    assert merged_excerpt["poem_id"] == excerpt1_label1.poem_id
+    assert merged_excerpt["alt_poem_ids"] == [excerpt1_label2.poem_id]
 
 
 def test_merge_excerpts():

--- a/tests/test_poetry_detection/test_merge_excerpts.py
+++ b/tests/test_poetry_detection/test_merge_excerpts.py
@@ -64,35 +64,55 @@ excerpt2_label1 = LabeledExcerpt.from_excerpt(
 
 
 def test_merge_excerpts_1ex_1label():
-    # excerpt + labeled excerpt (same id)
+    # excerpt + labeled excerpt (same id, same method, same span)
     df = pl.from_dicts([excerpt1.to_dict(), excerpt1_label1.to_dict()])
     merged = merge_excerpts(df)
-    # expect one row
+    # expect one row (excerpts have been merged)
     assert len(merged) == 1
     # should have all columns for labeled excerpt (order-agnostic)
     assert set(merged.columns) == set(LabeledExcerpt.fieldnames())
     row = merged.row(0, named=True)
     merged_excerpt = LabeledExcerpt.from_dict(row)
-    # result should exactly match the labeled excerpt since all other fields are same
-    assert merged_excerpt == excerpt1_label1
+    # existing notes should be present
+    assert excerpt1_label1.notes in merged_excerpt.notes
+    # merge info should be added to notes
+    assert "merge: ppa exact span, 2 excerpts" in merged_excerpt.notes
+
+    # result should exactly match the labeled excerpt since all fields are same
+    # other than notes; override the notes to simplify the check
+    excerpt1_label1_notes = LabeledExcerpt.from_excerpt(
+        excerpt1_label1, notes=merged_excerpt.notes
+    )
+    assert merged_excerpt == excerpt1_label1_notes
 
 
 def test_merge_excerpts_1ex_2labels(capsys):
-    # excerpt + two labeled excerpt (same excerpt id, two different ref ids)
+    # excerpt + two labeled excerpt (same excerpt id, two different poem ids)
     df = pl.from_dicts(
         [excerpt1.to_dict(), excerpt1_label1.to_dict(), excerpt1_label2.to_dict()]
     )
     merged = merge_excerpts(df)
-    # expect two rows with two different labels
-    assert len(merged) == 2
-    # original order is not guaranteed, so check presence in list
-    result_excerpts = [
-        LabeledExcerpt.from_dict(row) for row in merged.iter_rows(named=True)
-    ]
-    # results should exactly match the labeled excerpts since all other fields are same
-    # input excerpts should both be present unchanged in the output
-    assert excerpt1_label1 in result_excerpts
-    assert excerpt1_label2 in result_excerpts
+    # expect one row with combined labels
+    assert len(merged) == 1
+    merged_excerpt = LabeledExcerpt.from_dict(merged.row(0, named=True))
+    # existing notes should be present
+    for excerpt in [excerpt1, excerpt1_label1, excerpt1_label2]:
+        if excerpt.notes:
+            assert excerpt.notes in merged_excerpt.notes
+    # merge info should be added to notes
+    assert "merge: ppa exact span, 3 excerpts" in merged_excerpt.notes
+
+    # id methods should be combined
+    merged_excerpt.identification_methods == excerpt1_label1.identification_methods & excerpt1_label2.identification_methods
+    # multiple poem id currently combined in one field  (TODO: alt poem id field?)
+    assert merged_excerpt.poem_id == "; ".join(
+        [excerpt1_label1.poem_id, excerpt1_label2.poem_id]
+    )
+    # all other fields should be unchanged
+    for field in LabeledExcerpt.fieldnames():
+        # all other fields should have the same content in the merged excerpt
+        if field not in ["notes", "poem_id", "identification_methods"]:
+            assert getattr(merged_excerpt, field) == getattr(excerpt1_label1, field)
 
 
 def test_merge_excerpts_1ex_note_1label():
@@ -107,7 +127,12 @@ def test_merge_excerpts_1ex_note_1label():
     merged_excerpt = LabeledExcerpt.from_dict(merged.row(0, named=True))
     # result should match the labeled excerpt except for the updated notes field
     assert merged_excerpt != excerpt1_label1
-    expected_notes = "\n".join([ex1_notes.notes, excerpt1_label1.notes])
+    # notes should be combined, and merge info should be added
+    expected_merge_note = "merge: ppa exact span, 2 excerpts"
+    expected_notes = "; ".join(
+        [ex1_notes.notes, excerpt1_label1.notes, expected_merge_note]
+    )
+    assert merged_excerpt.notes == expected_notes
     excerpt_with_notes = replace(excerpt1_label1, notes=expected_notes)
     assert merged_excerpt == excerpt_with_notes
 
@@ -159,15 +184,28 @@ def test_merge_excerpts_multiple_diff_labels(capsys):
     # = two labeled excerpts each for the two poem_ids in label 1 and label 2
     df = df.extend(df)
     merged = merge_excerpts(df)
-    # expect two rows with two different labels
-    assert len(merged) == 2
-    # order is not guaranteed to match output, so check for presence in output
-    result_excerpts = [
-        LabeledExcerpt.from_dict(row) for row in merged.iter_rows(named=True)
-    ]
-    # input excerpts should both be present unchanged in the output
-    assert excerpt1_label1 in result_excerpts
-    assert excerpt1_label2 in result_excerpts
+    # expect one rows with combined poem id
+    assert len(merged) == 1
+    merged_excerpt = LabeledExcerpt.from_dict(merged.row(0, named=True))
+    # notes should be combined, and merge info should be added
+    expected_merge_note = "merge: ppa exact span, 6 excerpts"
+    # excerpt1 has no notes
+    expected_notes = "; ".join(
+        [excerpt1_label1.notes, excerpt1_label2.notes, expected_merge_note]
+    )
+    assert merged_excerpt.notes == expected_notes
+
+    # identification methods should be combined
+    merged_excerpt.identification_methods == excerpt1_label1.identification_methods & excerpt1_label2.identification_methods
+
+    # multiple poem id currently combined in one field  (NOTE: update if we add alt poem id field)
+    assert merged_excerpt.poem_id == "; ".join(
+        [excerpt1_label1.poem_id, excerpt1_label2.poem_id]
+    )
+    for field in LabeledExcerpt.fieldnames():
+        # all other fields should have the same content in the merged excerpt
+        if field not in ["notes", "poem_id", "identification_methods"]:
+            assert getattr(merged_excerpt, field) == getattr(excerpt1_label1, field)
 
 
 def test_merge_excerpts_1ex_2labels_diffmethod():
@@ -191,13 +229,17 @@ def test_merge_excerpts_1ex_2labels_diffmethod():
 
 
 def test_merge_different_labels():
-    # combine should NOT merge labeled excerpts with different poem id
-    excerpt1_diff_label = replace(excerpt1_label1, poem_id="Z1234")
+    # revised merge logic SHOULD merge labeled excerpts with different poem id
+    alt_poem_id = "Z1234"
+    excerpt1_diff_label = replace(excerpt1_label1, poem_id=alt_poem_id)
     df = pl.from_dicts([excerpt1_label1.to_dict(), excerpt1_diff_label.to_dict()])
 
-    # distinct poem ids should NOT be merged
+    # distinct poem ids combined when span matches exactly
     merged = merge_excerpts(df)
-    assert len(merged) == 2
+    assert len(merged) == 1
+    assert merged.row(0, named=True)["poem_id"] == "; ".join(
+        [alt_poem_id, excerpt1_label1.poem_id]
+    )
 
 
 # revise to merge labeled + unlabeled excerpts
@@ -208,8 +250,11 @@ def test_merge_unlabeled_labeled_excerpts():
     # we expect a single row
     assert len(merged) == 1
     excerpt = LabeledExcerpt.from_dict(merged.row(0, named=True))
-    # should match the labeled excerpt, since everything else was the same
-    assert excerpt == excerpt1_label1
+    # merge info added to notes
+    expected_merge_note = "merge: ppa exact span, 2 excerpts"
+    assert expected_merge_note in excerpt.notes
+    # should match the labeled excerpt, other than notes; everything else was the same
+    assert replace(excerpt, notes=None) == replace(excerpt1_label1, notes=None)
 
     # excerpt + excerpt with notes
     excerpt_with_notes = replace(excerpt1, notes="could not identify")
@@ -221,9 +266,8 @@ def test_merge_unlabeled_labeled_excerpts():
     # should not match the labeled excerpt, since notes should be combined
     assert excerpt != excerpt1_label1
     # notes contents from both merged excerpts should be present
-    assert excerpt_with_notes.notes in excerpt.notes
-    assert excerpt1_label1.notes in excerpt.notes
-    assert excerpt.notes == f"{excerpt_with_notes.notes}\n{excerpt1_label1.notes}"
+    for note in [excerpt_with_notes.notes, excerpt1_label1.notes, expected_merge_note]:
+        assert note in excerpt.notes
 
     # excerpt with notes and two labeled excerpts that can't be merged
     # - notes are merged to the first matching labeled excerpt
@@ -236,14 +280,21 @@ def test_merge_unlabeled_labeled_excerpts():
         ]
     )
     merged = merge_excerpts(df)
-    # we expect two rows
-    assert len(merged) == 2
-    # order is not guaranteed; test against a list of merged note contents
-    merged_notes = merged["notes"].to_list()
-    # unlabeled excerpt and excerpt1 label 1 are combined
-    assert f"{excerpt_with_notes.notes}\n{excerpt1_label1.notes}" in merged_notes
-    # second labeled excerpt does not currently get unlabeled excerpt notes
-    assert excerpt1_label2.notes in merged_notes
+    # we expect one row with combined poem ids
+    assert len(merged) == 1
+    merged_excerpt = merged.row(0, named=True)
+    expected_merge_note = "merge: ppa exact span, 3 excerpts"
+    # notes contents from both merged excerpts should be present
+    for note in [
+        excerpt_with_notes.notes,
+        excerpt1_label1.notes,
+        excerpt1_label2.notes,
+        expected_merge_note,
+    ]:
+        assert note in merged_excerpt["notes"]
+    assert merged_excerpt["poem_id"] == "; ".join(
+        [excerpt1_label1.poem_id, excerpt1_label2.poem_id]
+    )
 
 
 def test_merge_excerpts():

--- a/tests/test_poetry_detection/test_merge_excerpts.py
+++ b/tests/test_poetry_detection/test_merge_excerpts.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025, Center for Digital Humanities, Princeton University
+# Copyright (c) 2024-2026, Center for Digital Humanities, Princeton University
 # SPDX-License-Identifier: Apache-2.0
 
 import csv
@@ -174,6 +174,23 @@ def test_merge_excerpts_two_different_labels():
     # input excerpts should both be present unchanged in the output
     assert excerpt1_label1 in result_excerpts
     assert excerpt2_label1 in result_excerpts
+
+
+def test_merge_passim_match_len():
+    # passim match length should take precedence over sort by poem id
+    long_excerpt1 = replace(
+        excerpt1_label1, poem_id="z", notes="passim: 442 char matches"
+    )
+    shorter_excerpt2 = replace(
+        excerpt1_label1, poem_id="a", notes="passim: 213 char matches"
+    )
+    df = pl.from_dicts([shorter_excerpt2.to_dict(), long_excerpt1.to_dict()])
+    merged = merge_excerpts(df)
+    # expect one row
+    assert len(merged) == 1
+    # longer match should take precedence
+    merged_excerpt = LabeledExcerpt.from_dict(merged.row(0, named=True))
+    assert merged_excerpt.poem_id == long_excerpt1.poem_id
 
 
 def test_merge_excerpts_multiple_diff_labels(capsys):

--- a/tests/test_poetry_detection/test_polars_utils.py
+++ b/tests/test_poetry_detection/test_polars_utils.py
@@ -331,3 +331,25 @@ def test_add_poems_meta(mock_load_meta_df):
         with pytest.raises(ValueError, match=err_msg):
             add_ref_poems_meta(bad_df, "poem_meta")
         mock_load_meta_df.assert_not_called()
+
+    # join on alternate field names
+    alt_excerpts_df = excerpts_df.with_columns(
+        alt_poem_id=pl.col("poem_id"), alt_ref_corpus=pl.col("ref_corpus")
+    )
+    with patch.object(alt_excerpts_df, "join") as mock_join:
+        add_ref_poems_meta(
+            alt_excerpts_df, "poem_meta", "alt_poem_id", "alt_ref_corpus", "_alt"
+        )
+        mock_join.assert_called_once_with(
+            poem_meta_df,
+            left_on=["alt_poem_id", "alt_ref_corpus"],
+            right_on=["poem_id", "ref_corpus"],
+            how="left",
+            suffix="_alt",
+        )
+
+    # validation on custom fields
+    with pytest.raises(ValueError, match="required fields: alt_poem_id"):
+        add_ref_poems_meta(excerpts_df, "poem_meta", "alt_poem_id")
+    with pytest.raises(ValueError, match="required fields: alt_ref_corpus"):
+        add_ref_poems_meta(excerpts_df, "poem_meta", ref_corpus_field="alt_ref_corpus")


### PR DESCRIPTION
**Associated Issue(s):** resolves #255

### Changes in this PR

- Revise existing merge logic so all excerpts with matching ppa spans are consolidated
- Rewrites merge logic to use polars rather than a loop (much faster!)

### Notes

- Consolidated poem id isn't useful for joining; what do you think of adding an alt_poem_ids field for additional ids? Then we can privilege one reference id / span but keep the other ids as possible/likely duplicates
- Test cases are probably redundant, especially now that the merge logic is simpler than before
