### PR TITLE
Revise found poems compilation in preparation for publishing v0.5

### DIFF
--- a/notebooks/excerpt_overlap_review.ipynb
+++ b/notebooks/excerpt_overlap_review.ipynb
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "id": "c95992e4-de1f-41ce-922e-ddfd0c15a2a7",
    "metadata": {},
    "outputs": [],
@@ -28,7 +28,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "5501e39d-d5d9-497b-9739-ee96d1bb8939",
    "metadata": {},
    "outputs": [
@@ -36,7 +36,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Data will be loaded from /Users/lauret/cdh-dev/ppa/ppa-found-poems/data\n"
+      "Data will be loaded from sample_data\n"
      ]
     }
    ],
@@ -44,7 +44,7 @@
     "# load local configuration options to get path to data\n",
     "config_opts = get_config()\n",
     "\n",
-    "data_dir = pathlib.Path(config_opts[\"poem_dataset\"][\"data_dir\"])\n",
+    "data_dir = pathlib.Path(config_opts.compiled_dataset_dir)\n",
     "if not data_dir.exists() or not data_dir.is_dir():\n",
     "    raise ValueError(f\"Data directory {data_dir} not found. \" + \n",
     "                     \"\\nCheck your configuration file, and remember to use an absolute path for the poem dataset data directory.\")\n",
@@ -776,7 +776,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.10"
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,

--- a/notebooks/sample_data/test_config.yml
+++ b/notebooks/sample_data/test_config.yml
@@ -2,9 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # corppa configuration for automated tests / continuous integration
+base_dir: .
 
 # local path to compiled poem dataset files
-poem_dataset:
-  # Use relative path for CI, since the path depends on the build.
-  # For notebooks, relative path starts from the notebook directory.
-  data_dir: "sample_data/"
+# Use relative path for CI, since the path depends on the build.
+# For notebooks, relative path starts from the notebook directory.
+compiled_dataset_dir: sample_data
+

--- a/sample_config.yml
+++ b/sample_config.yml
@@ -16,7 +16,7 @@
 base_dir: data/tigerdata-foundpoems-v0.5/
 
 # local path to compiled poem dataset files
-compiled_dataset: /path/to/ppa-found-poems/data/
+compiled_dataset_dir: /path/to/ppa-found-poems/data/
 
 # source excerpt data; relative to base_dir unless absolute
 excerpt_data_dir: excerpt-data

--- a/sample_config.yml
+++ b/sample_config.yml
@@ -4,39 +4,50 @@
 # corppa configuration
 # copy this file to corppa_config.yml and edit as needed
 
+# to compile found poems v0.5 dataset, copy the following
+# from tigerdata prosody project under poetry-detection/2026-05-foundpoems-v0.5/
+#.     ref-corpora/
+#      ppa-corpus_2026-01-07/
+#.     excerpt-data/
+# Copy to a local directory, preserving relative paths. Set that local directory
+# as your top-level base_dir below.
+
 # top-level path for excerpt dataset ingredients
- data_ingredients_dir: /tigerdata/cdh/prosody/excerpt-data-ingredients/
+base_dir: data/tigerdata-foundpoems-v0.5/
 
 # local path to compiled poem dataset files
-compiled_dataset:
-  # NOTE: currently requires an absolute path, since jupyter
-  # notebooks will try to load relative to the notebook
-  data_dir: "/path/to/ppa-found-poems/data/"
+compiled_dataset: /path/to/ppa-found-poems/data/
+
+# source excerpt data; relative to base_dir unless absolute
+excerpt_data_dir: excerpt-data
+
+# PPA full-text corpus and metadata; relative to base_dir unless absolute
+ppa_corpus:
+  base_dir: ppa_corpus_20XX-XX-XX/
+
+# poem cluster ids
+# poem_clusters_path: https://
 
 # paths to reference corpora metadata and text
 reference_corpora:
   # default base_dir is data_ingredients_dir / ref-corpora
-  # uncomment to override; assumed relative to data_ingredients_dir if not absolute
+  # uncomment to override; assumed relative to base_dir if not absolute
   # base_dir: ref-corpora/
 
-  # poem cluster ids; path or URL to CSV with clusters of duplicate poems
-  # poem_clusters_path:
+  # Paths for individual corpora are assumed relative to reference_corpora.base_dir
+  # unless absolute; uncomment to override.
+  # text_path can be a tar.gz directory of text files or expanded directory.
 
+  internet_poems:
+    # base_dir: internet_poems
+    # text_path: internet_poems_texts.tar.gz
+    # metadata_path: internet-poems-metadata.csv
 
-  # Uses default paths relative to reference_corpora.base_dir
-  # Uncomment to override if needed; if path is not absolute,
-  # will be assumed relative to reference_corpora base_dir
-
-  # internet_poems:
-    # tarball of directory of text files OR expanded directory;
-    # some functionality will only work with the expanded directory
-    # text_path: "internet_poems/internet_poems_texts.tar.gz"
-  # chadwyck-healey:
-    # tarball of directory of text files OR expanded directory;
-    # some functionality will only work with the expanded directory
+  chadwyck-healey:
+    # base_dir: chadwyck-healey
     # text_path: "chadwyck-healey/chadwyck-healey_texts.tar.gz"
     # metadata_path: "chadwyck-healey/chadwyck-healey.csv"
   other:
-    # Provide a URL or local path to "Other Poems" metadata
+    # URL or local path to "Other Poems" metadata
     # Use a URL if you want to pull directly from google sheets as CSV or
     metadata_path: "https://docs.google.com/spreadsheets/d/..."  # or "/path/to/other.csv"

--- a/sample_config.yml
+++ b/sample_config.yml
@@ -19,6 +19,10 @@ reference_corpora:
   # uncomment to override; assumed relative to data_ingredients_dir if not absolute
   # base_dir: ref-corpora/
 
+  # poem cluster ids; path or URL to CSV with clusters of duplicate poems
+  # poem_clusters_path:
+
+
   # Uses default paths relative to reference_corpora.base_dir
   # Uncomment to override if needed; if path is not absolute,
   # will be assumed relative to reference_corpora base_dir

--- a/src/corppa/config.py
+++ b/src/corppa/config.py
@@ -88,16 +88,20 @@ class CorpusConfig:
 
     def validate(self, text=True, metadata=True) -> bool:
         if text:
-            if not self.text_path.exists():
+            if self.text_path is None:
                 raise ValueError(
-                    f"Configuration error: {self.name} path {self.text_path} does not exist"
+                    f"Configuration error: {self.name} text_path is not set"
+                )
+            elif not self.text_path.exists():
+                raise ValueError(
+                    f"Configuration error: {self.name} text_path {self.text_path} does not exist"
                 )
             # Currently supports directory and tar.gz file
             if not self.text_path.is_dir() and not (
                 self.text_path.is_file() and self.text_path.name.endswith(".tar.gz")
             ):
                 raise ValueError(
-                    f"Configuration error: {self.name} path {self.text_path} is not a directory or a tar.gz"
+                    f"Configuration error: {self.name} text_path {self.text_path} is not a directory or a tar.gz"
                 )
         if metadata:
             if (
@@ -105,7 +109,7 @@ class CorpusConfig:
                 and not self.metadata_path.is_file()
             ):
                 raise ValueError(
-                    f"Configuration error: {self.name} metadata {self.metadata_path} does not exist"
+                    f"Configuration error: {self.name} metadata_path {self.metadata_path} does not exist"
                 )
 
         return True

--- a/src/corppa/config.py
+++ b/src/corppa/config.py
@@ -87,6 +87,11 @@ class CorpusConfig:
         self.metadata_path = resolve_path(self.metadata_path, self.base_dir)
 
     def validate(self, text=True, metadata=True) -> bool:
+        """Check that configured paths are valid.  By default, checks both
+        text and metadata paths to confirm they are set and appropriate
+        supported file types (directory or .tar.gz for text path, file for metadata).
+        Raises ValueError for any configuration error.
+        """
         if text:
             if self.text_path is None:
                 raise ValueError(
@@ -104,6 +109,10 @@ class CorpusConfig:
                     f"Configuration error: {self.name} text_path {self.text_path} is not a directory or a tar.gz"
                 )
         if metadata:
+            if not self.metadata_path:  # check for None or empty string
+                raise ValueError(
+                    f"Configuration error: {self.name} metadata_path is not set"
+                )
             if (
                 isinstance(self.metadata_path, Path)
                 and not self.metadata_path.is_file()
@@ -151,9 +160,7 @@ class ConfigOpts:
 
     def __post_init__(self):
         self.excerpt_data_dir = resolve_path(self.excerpt_data_dir, self.base_dir)
-        self.compiled_dataset_dir = resolve_path(
-            self.compiled_dataset_dir, self.base_dir
-        )
+        # compiled dataset dir is NOT assumed relative to base dir
 
 
 def get_config():

--- a/src/corppa/config.py
+++ b/src/corppa/config.py
@@ -118,7 +118,7 @@ class CorpusConfig:
 @dataclass
 class PPACorpusConfig(CorpusConfig):
     """
-    PPA corpus config. Defines suffixes to for text
+    PPA corpus config. Defines suffixes for text
     and metadata to match the known filenames used in PPA full-text dataset.
     """
 

--- a/src/corppa/config.py
+++ b/src/corppa/config.py
@@ -17,15 +17,16 @@ except ImportError:  # pragma: no cover
     from yaml import Loader  # pragma: no cover
 
 
-def resolve_path(path: str | Path | None, base_dir: Path) -> Path | None:
+def resolve_path(path: str | Path | None, base_dir: Path) -> Path | str | None:
     """Convert to Path and make relative to base_dir if not absolute."""
     if path is None:
         return None
     if isinstance(path, str):
-        path = Path(path)
-        # check for URL; don't make relative to base dir
-        if str(path).startswith("http"):
+        # check for URL; don't convert to path but keep as-is
+        if path.startswith("http"):
             return path
+        # otherwise, convert string to path and make relative
+        path = Path(path)
     if not path.is_absolute() and not path.is_relative_to(base_dir):
         path = base_dir / path
     return path
@@ -85,9 +86,10 @@ class CorpusConfig:
                     f"Configuration error: {self.name} path {self.text_path} is not a directory or a tar.gz"
                 )
         if metadata:
-            if not self.metadata_path.is_file() and not str(
-                self.metadata_path
-            ).startswith("http"):
+            if (
+                isinstance(self.metadata_path, Path)
+                and not self.metadata_path.is_file()
+            ):
                 raise ValueError(
                     f"Configuration error: {self.name} metadata {self.metadata_path} does not exist"
                 )

--- a/src/corppa/config.py
+++ b/src/corppa/config.py
@@ -31,6 +31,7 @@ class CorpusConfig:
     base_dir: Optional[Path] = None
     text_path: Optional[Path] = None
     metadata_path: Optional[Path] = None
+    relative_dir: Optional[Path] = None
 
     _path_suffix: ClassVar[dict[str, str]] = {
         "text": "_texts.tar.gz",
@@ -41,6 +42,12 @@ class CorpusConfig:
         # set paths based on defaults for any paths not passed in
         if self.base_dir is None:
             self.base_dir = Path(self.name)
+        # optionally make base dir relative to another dir
+        # (most important for case where default base dir is inferred from name)
+        if self.relative_dir is not None and not self.base_dir.is_relative_to(
+            self.relative_dir
+        ):
+            self.base_dir = self.relative_dir / self.base_dir
         # if not set, use the default path
         if self.text_path is None:
             self.text_path = self.base_dir / f"{self.name}{self._path_suffix['text']}"
@@ -83,7 +90,7 @@ class ConfigOpts:
     base_dir: Path
     compiled_dataset_dir: Path
     ppa_corpus: Optional[PPACorpusConfig] = None
-    reference_corpora: dict[str, CorpusConfig] = field(default_factory=list)  # type: ignore[arg-type]
+    reference_corpora: dict[str, CorpusConfig] = field(default_factory=dict)  # type: ignore[arg-type]
     excerpt_data_dir: Optional[Path] = None
     poem_clusters_path: Optional[str] = (
         None  # currently expect a url rather than local path
@@ -137,14 +144,24 @@ def get_config():
             raise SystemExit(f"Error parsing config file: {err}")
 
     try:
-        ref_corpus_configs = []
+        base_dir = Path(config_values["base_dir"])
+        ref_corpus_configs = {}
         # allow ref corpora config to be optional
         if "reference_corpora" in config_values:
             ref_corpus_base_dir = config_values["reference_corpora"].get("base_dir")
             if ref_corpus_base_dir is not None:
                 ref_corpus_base_dir = Path(ref_corpus_base_dir)
-                # remove from dict before iterating over sections
+                if (
+                    not ref_corpus_base_dir.is_absolute()
+                    and not ref_corpus_base_dir.is_relative_to(base_dir)
+                ):
+                    ref_corpus_base_dir = base_dir / ref_corpus_base_dir
+
+                # remove base_dir from dict before iterating over sections
                 del config_values["reference_corpora"]["base_dir"]
+            else:
+                # if now ref-corpus base dir is specified, use top-level as base dir
+                ref_corpus_base_dir = base_dir
 
             for section, values in config_values["reference_corpora"].items():
                 # when section is empty, values is None; convert to empty dict
@@ -162,23 +179,25 @@ def get_config():
                     ):
                         section_base_dir = ref_corpus_base_dir / section_base_dir
 
-                ref_corpus_configs.append(
-                    CorpusConfig(
-                        name=section,
-                        base_dir=section_base_dir,
-                        text_path=values.get("text_path"),
-                        metadata_path=values.get("metadata_path"),
-                    )
+                # FIXME: default needs an optional relative to base path here
+                ref_corpus_configs[section] = CorpusConfig(
+                    name=section,
+                    base_dir=section_base_dir,
+                    text_path=values.get("text_path"),
+                    metadata_path=values.get("metadata_path"),
+                    relative_dir=ref_corpus_base_dir,
                 )
         # allow ppa corpus to be optional
         ppa_corpus = None
         if "ppa_corpus" in config_values:
-            ppa_corpus = PPACorpusConfig(config_values["ppa_corpus"]["base_dir"])
+            ppa_corpus = PPACorpusConfig(
+                base_dir=Path(config_values["ppa_corpus"]["base_dir"])
+            )
 
         # use direct access for required values to trigger a KeyError
 
         return ConfigOpts(
-            base_dir=Path(config_values["base_dir"]),
+            base_dir=base_dir,
             compiled_dataset_dir=Path(config_values["compiled_dataset_dir"]),
             ppa_corpus=ppa_corpus,
             reference_corpora=ref_corpus_configs,

--- a/src/corppa/config.py
+++ b/src/corppa/config.py
@@ -16,6 +16,18 @@ try:
 except ImportError:  # pragma: no cover
     from yaml import Loader  # pragma: no cover
 
+
+def resolve_path(path: str | Path | None, base_dir: Path) -> Path | None:
+    """Convert to Path and make relative to base_dir if not absolute."""
+    if path is None:
+        return None
+    if isinstance(path, str):
+        path = Path(path)
+    if not path.is_absolute() and not path.is_relative_to(base_dir):
+        path = base_dir / path
+    return path
+
+
 #: src dir relative to this file (assuming dev environment for now)
 CORPPA_SRC_DIR = Path(__file__).parent.parent.absolute()
 
@@ -39,7 +51,6 @@ class CorpusConfig:
     }
 
     def __post_init__(self):
-        # set paths based on defaults for any paths not passed in
         if self.base_dir is None:
             self.base_dir = Path(self.name)
         # optionally make base dir relative to another dir
@@ -48,31 +59,18 @@ class CorpusConfig:
             self.relative_dir
         ):
             self.base_dir = self.relative_dir / self.base_dir
-        # if not set, use the default path
+
         if self.text_path is None:
             self.text_path = self.base_dir / f"{self.name}{self._path_suffix['text']}"
         else:
-            # allow passing as config to simplify optional config logic
-            if isinstance(self.text_path, str):
-                self.text_path = Path(self.text_path)
-            if not self.text_path.is_absolute() and not self.text_path.is_relative_to(
-                self.base_dir
-            ):
-                # if set, make path is relative to base dir
-                self.text_path = self.base_dir / self.text_path
+            self.text_path = resolve_path(self.text_path, self.base_dir)
 
         if self.metadata_path is None:
             self.metadata_path = (
                 self.base_dir / f"{self.name}{self._path_suffix['metadata']}"
             )
         else:
-            if isinstance(self.metadata_path, str):
-                self.metadata_path = Path(self.metadata_path)
-            if (
-                not self.metadata_path.is_absolute()
-                and not self.metadata_path.is_relative_to(self.base_dir)
-            ):
-                self.metadata_path = self.base_dir / self.metadata_path
+            self.metadata_path = resolve_path(self.metadata_path, self.base_dir)
 
 
 @dataclass
@@ -97,34 +95,10 @@ class ConfigOpts:
     )
 
     def __post_init__(self):
-        # convert string to path to simplify optional config handling
-        if self.excerpt_data_dir is not None:
-            if isinstance(self.excerpt_data_dir, str):
-                self.excerpt_data_dir = Path(self.excerpt_data_dir)
-            if (
-                not self.excerpt_data_dir.is_absolute()
-                and not self.excerpt_data_dir.is_relative_to(self.base_dir)
-            ):
-                self.excerpt_data_dir = self.base_dir / self.excerpt_data_dir
-
-        if self.compiled_dataset_dir is not None:
-            if isinstance(self.compiled_dataset_dir, str):
-                self.compiled_dataset_dir = Path(self.compiled_dataset_dir)
-            if (
-                not self.compiled_dataset_dir.is_absolute()
-                and not self.compiled_dataset_dir.is_relative_to(self.base_dir)
-            ):
-                self.compiled_dataset_dir = self.base_dir / self.compiled_dataset_dir
-
-
-# assume defaults
-# - ppa data standard file names are known
-# - config logic should be in one place
-# - use path objects
-# .  - make relative
-# .  - validate
-# - simple: list / dict defaults (ref corpora)
-#   - easy to add in future (follows pattern)
+        self.excerpt_data_dir = resolve_path(self.excerpt_data_dir, self.base_dir)
+        self.compiled_dataset_dir = resolve_path(
+            self.compiled_dataset_dir, self.base_dir
+        )
 
 
 def get_config():
@@ -148,38 +122,24 @@ def get_config():
         ref_corpus_configs = {}
         # allow ref corpora config to be optional
         if "reference_corpora" in config_values:
-            ref_corpus_base_dir = config_values["reference_corpora"].get("base_dir")
-            if ref_corpus_base_dir is not None:
-                ref_corpus_base_dir = Path(ref_corpus_base_dir)
-                if (
-                    not ref_corpus_base_dir.is_absolute()
-                    and not ref_corpus_base_dir.is_relative_to(base_dir)
-                ):
-                    ref_corpus_base_dir = base_dir / ref_corpus_base_dir
-
+            ref_corpus_base_dir = (
+                resolve_path(
+                    config_values["reference_corpora"].get("base_dir"), base_dir
+                )
+                or base_dir
+            )
+            if "base_dir" in config_values["reference_corpora"]:
                 # remove base_dir from dict before iterating over sections
                 del config_values["reference_corpora"]["base_dir"]
-            else:
-                # if now ref-corpus base dir is specified, use top-level as base dir
-                ref_corpus_base_dir = base_dir
 
             for section, values in config_values["reference_corpora"].items():
                 # when section is empty, values is None; convert to empty dict
                 if values is None:
                     values = {}
 
-                # if base dir is set for this corpus, use it;
-                # make relative to ref corpus base dir when set, unless absolute
-                section_base_dir = values.get("base_dir")
-                if section_base_dir is not None:
-                    section_base_dir = Path(section_base_dir)
-                    if (
-                        ref_corpus_base_dir is not None
-                        and not section_base_dir.is_absolute()
-                    ):
-                        section_base_dir = ref_corpus_base_dir / section_base_dir
-
-                # FIXME: default needs an optional relative to base path here
+                section_base_dir = resolve_path(
+                    values.get("base_dir"), ref_corpus_base_dir
+                )
                 ref_corpus_configs[section] = CorpusConfig(
                     name=section,
                     base_dir=section_base_dir,

--- a/src/corppa/config.py
+++ b/src/corppa/config.py
@@ -207,7 +207,8 @@ def get_config():
         ppa_corpus = None
         if "ppa_corpus" in config_values:
             ppa_corpus = PPACorpusConfig(
-                base_dir=Path(config_values["ppa_corpus"]["base_dir"])
+                base_dir=Path(config_values["ppa_corpus"]["base_dir"]),
+                relative_dir=base_dir,
             )
         return ConfigOpts(
             base_dir=base_dir,

--- a/src/corppa/config.py
+++ b/src/corppa/config.py
@@ -5,7 +5,9 @@
 Load local configuration options
 """
 
-import pathlib
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import ClassVar, Optional
 
 import yaml
 
@@ -15,50 +17,107 @@ except ImportError:  # pragma: no cover
     from yaml import Loader  # pragma: no cover
 
 #: src dir relative to this file (assuming dev environment for now)
-CORPPA_SRC_DIR = pathlib.Path(__file__).parent.parent.absolute()
+CORPPA_SRC_DIR = Path(__file__).parent.parent.absolute()
 
 #: expected path for local config file (non-versioned)
 CORPPA_CONFIG_PATH = CORPPA_SRC_DIR.parent / "corppa_config.yml"
 #: expected path for example config file
 SAMPLE_CONFIG_PATH = CORPPA_SRC_DIR.parent / "sample_config.yml"
 
-#: default configuration; anything in yaml config will override
-DEFAULTS = {
-    "reference_corpora": {
-        # base_dir path is relative to top-level data_ingredients_dir
-        "base_dir": "ref-corpora",
-        # paths are relative to base_dir
-        "internet_poems": {
-            # tarball of text files OR expanded directory
-            "text_path": "internet_poems/internet_poems_texts.tar.gz"
-        },
-        "chadwyck-healey": {
-            "text_path": "chadwyck-healey/chadwyck-healey_texts.tar.gz",
-            "metadata_path": "chadwyck-healey/chadwyck-healey.csv",
-        },
-        # other poems metadata_path configuration required
+
+@dataclass
+class CorpusConfig:
+    name: str
+    base_dir: Optional[Path] = None
+    text_path: Optional[Path] = None
+    metadata_path: Optional[Path] = None
+
+    _path_suffix: ClassVar[dict[str, str]] = {
+        "text": "_texts.tar.gz",
+        "metadata": ".csv",
     }
-}
 
-
-def merge_dicts(initial_values: dict, overrides: dict) -> dict:
-    """Recursively merge two dictionaries. Anything values in second dict
-    take precedence over the first. Nested dictionaries are merged
-    by calling :meth:`merge_dicts`.
-    """
-    merged_dict = initial_values.copy()
-    for key, value in overrides.items():
-        # if the override value is a dict and key is present in both,
-        # then merge the nested dicts
-        if isinstance(value, dict) and key in merged_dict:
-            # note: assumes they are both dicts; this should be safe
-            # for our config file setup
-            merged_dict[key] = merge_dicts(initial_values[key], overrides[key])
-        # otherwise, set the value from the override dictionary
+    def __post_init__(self):
+        # set paths based on defaults for any paths not passed in
+        if self.base_dir is None:
+            self.base_dir = Path(self.name)
+        # if not set, use the default path
+        if self.text_path is None:
+            self.text_path = self.base_dir / f"{self.name}{self._path_suffix['text']}"
         else:
-            merged_dict[key] = value
+            # allow passing as config to simplify optional config logic
+            if isinstance(self.text_path, str):
+                self.text_path = Path(self.text_path)
+            if not self.text_path.is_absolute() and not self.text_path.is_relative_to(
+                self.base_dir
+            ):
+                # if set, make path is relative to base dir
+                self.text_path = self.base_dir / self.text_path
 
-    return merged_dict
+        if self.metadata_path is None:
+            self.metadata_path = (
+                self.base_dir / f"{self.name}{self._path_suffix['metadata']}"
+            )
+        else:
+            if isinstance(self.metadata_path, str):
+                self.metadata_path = Path(self.metadata_path)
+            if (
+                not self.metadata_path.is_absolute()
+                and not self.metadata_path.is_relative_to(self.base_dir)
+            ):
+                self.metadata_path = self.base_dir / self.metadata_path
+
+
+@dataclass
+class PPACorpusConfig(CorpusConfig):
+    # subclass for ppa corpus config; which has known filenames
+    name: str = "ppa"
+    _path_suffix: ClassVar[dict[str, str]] = {
+        "text": "_pages.jsonl.gz",
+        "metadata": "_metadata.csv",
+    }
+
+
+@dataclass
+class ConfigOpts:
+    base_dir: Path
+    compiled_dataset_dir: Path
+    ppa_corpus: Optional[PPACorpusConfig] = None
+    reference_corpora: dict[str, CorpusConfig] = field(default_factory=list)  # type: ignore[arg-type]
+    excerpt_data_dir: Optional[Path] = None
+    poem_clusters_path: Optional[str] = (
+        None  # currently expect a url rather than local path
+    )
+
+    def __post_init__(self):
+        # convert string to path to simplify optional config handling
+        if self.excerpt_data_dir is not None:
+            if isinstance(self.excerpt_data_dir, str):
+                self.excerpt_data_dir = Path(self.excerpt_data_dir)
+            if (
+                not self.excerpt_data_dir.is_absolute()
+                and not self.excerpt_data_dir.is_relative_to(self.base_dir)
+            ):
+                self.excerpt_data_dir = self.base_dir / self.excerpt_data_dir
+
+        if self.compiled_dataset_dir is not None:
+            if isinstance(self.compiled_dataset_dir, str):
+                self.compiled_dataset_dir = Path(self.compiled_dataset_dir)
+            if (
+                not self.compiled_dataset_dir.is_absolute()
+                and not self.compiled_dataset_dir.is_relative_to(self.base_dir)
+            ):
+                self.compiled_dataset_dir = self.base_dir / self.compiled_dataset_dir
+
+
+# assume defaults
+# - ppa data standard file names are known
+# - config logic should be in one place
+# - use path objects
+# .  - make relative
+# .  - validate
+# - simple: list / dict defaults (ref corpora)
+#   - easy to add in future (follows pattern)
 
 
 def get_config():
@@ -73,10 +132,60 @@ def get_config():
     with CORPPA_CONFIG_PATH.open() as cfg_file:
         try:
             # configuration in the yaml file should override any defaults
-            config_overrides = yaml.load(cfg_file, Loader=Loader)
+            config_values = yaml.load(cfg_file, Loader=Loader)
         except yaml.parser.ParserError as err:
             raise SystemExit(f"Error parsing config file: {err}")
 
-    # use default config as the starting point; settings loaded from the config
-    # file should override
-    return merge_dicts(DEFAULTS, config_overrides)
+    try:
+        ref_corpus_configs = []
+        # allow ref corpora config to be optional
+        if "reference_corpora" in config_values:
+            ref_corpus_base_dir = config_values["reference_corpora"].get("base_dir")
+            if ref_corpus_base_dir is not None:
+                ref_corpus_base_dir = Path(ref_corpus_base_dir)
+                # remove from dict before iterating over sections
+                del config_values["reference_corpora"]["base_dir"]
+
+            for section, values in config_values["reference_corpora"].items():
+                # when section is empty, values is None; convert to empty dict
+                if values is None:
+                    values = {}
+
+                # if base dir is set for this corpus, use it;
+                # make relative to ref corpus base dir when set, unless absolute
+                section_base_dir = values.get("base_dir")
+                if section_base_dir is not None:
+                    section_base_dir = Path(section_base_dir)
+                    if (
+                        ref_corpus_base_dir is not None
+                        and not section_base_dir.is_absolute()
+                    ):
+                        section_base_dir = ref_corpus_base_dir / section_base_dir
+
+                ref_corpus_configs.append(
+                    CorpusConfig(
+                        name=section,
+                        base_dir=section_base_dir,
+                        text_path=values.get("text_path"),
+                        metadata_path=values.get("metadata_path"),
+                    )
+                )
+        # allow ppa corpus to be optional
+        ppa_corpus = None
+        if "ppa_corpus" in config_values:
+            ppa_corpus = PPACorpusConfig(config_values["ppa_corpus"]["base_dir"])
+
+        # use direct access for required values to trigger a KeyError
+
+        return ConfigOpts(
+            base_dir=Path(config_values["base_dir"]),
+            compiled_dataset_dir=Path(config_values["compiled_dataset_dir"]),
+            ppa_corpus=ppa_corpus,
+            reference_corpora=ref_corpus_configs,
+            excerpt_data_dir=config_values.get("excerpt_data_dir"),
+            poem_clusters_path=config_values.get("poem_clusters_path"),
+        )
+    except KeyError as err:
+        raise SystemExit(
+            f"Config file is missing required configuration: {err.args[0]}"
+        )

--- a/src/corppa/config.py
+++ b/src/corppa/config.py
@@ -55,22 +55,18 @@ class CorpusConfig:
             self.base_dir = Path(self.name)
         # optionally make base dir relative to another dir
         # (most important for case where default base dir is inferred from name)
-        if self.relative_dir is not None and not self.base_dir.is_relative_to(
-            self.relative_dir
-        ):
-            self.base_dir = self.relative_dir / self.base_dir
+        if self.relative_dir is not None:
+            self.base_dir = resolve_path(self.base_dir, self.relative_dir)
 
+        # if paths are not set, use name and default suffix;
+        # make paths relative to base dir
         if self.text_path is None:
-            self.text_path = self.base_dir / f"{self.name}{self._path_suffix['text']}"
-        else:
-            self.text_path = resolve_path(self.text_path, self.base_dir)
+            self.text_path = f"{self.name}{self._path_suffix['text']}"
+        self.text_path = resolve_path(self.text_path, self.base_dir)
 
         if self.metadata_path is None:
-            self.metadata_path = (
-                self.base_dir / f"{self.name}{self._path_suffix['metadata']}"
-            )
-        else:
-            self.metadata_path = resolve_path(self.metadata_path, self.base_dir)
+            self.metadata_path = f"{self.name}{self._path_suffix['metadata']}"
+        self.metadata_path = resolve_path(self.metadata_path, self.base_dir)
 
 
 @dataclass
@@ -118,6 +114,7 @@ def get_config():
             raise SystemExit(f"Error parsing config file: {err}")
 
     try:
+        # use direct access for required values to trigger a KeyError
         base_dir = Path(config_values["base_dir"])
         ref_corpus_configs = {}
         # allow ref corpora config to be optional
@@ -153,9 +150,6 @@ def get_config():
             ppa_corpus = PPACorpusConfig(
                 base_dir=Path(config_values["ppa_corpus"]["base_dir"])
             )
-
-        # use direct access for required values to trigger a KeyError
-
         return ConfigOpts(
             base_dir=base_dir,
             compiled_dataset_dir=Path(config_values["compiled_dataset_dir"]),

--- a/src/corppa/config.py
+++ b/src/corppa/config.py
@@ -43,10 +43,24 @@ SAMPLE_CONFIG_PATH = CORPPA_SRC_DIR.parent / "sample_config.yml"
 
 @dataclass
 class CorpusConfig:
+    """
+    Configuration for a single corpus. Includes a name, base directory,
+    text path, metadata path, and optional relative directory.  Only
+    name is required. If not specified, `base_dir` will be set based on
+    the corpus name; relative to `relative_dir` when present.  Similarly,
+    when not specified text and metadata paths will be set relative to
+    the corpus `base_dir` based on the defined suffixes.
+    """
+
+    #: corpus name or id
     name: str
+    #: base directory for corpus data
     base_dir: Optional[Path] = None
+    #: path to texts for this corpus (e.g., tar.gz or directory)
     text_path: Optional[Path] = None
+    #: path to metadata for this corpus
     metadata_path: Optional[Path] = None
+    #: optional relative directory that :attr:`base_dir`should be relative to
     relative_dir: Optional[Path] = None
 
     _path_suffix: ClassVar[dict[str, str]] = {
@@ -99,7 +113,11 @@ class CorpusConfig:
 
 @dataclass
 class PPACorpusConfig(CorpusConfig):
-    # subclass for ppa corpus config; which has known filenames
+    """
+    PPA corpus config. Defines suffixes to for text
+    and metadata to match the known filenames used in PPA full-text dataset.
+    """
+
     name: str = "ppa"
     _path_suffix: ClassVar[dict[str, str]] = {
         "text": "_pages.jsonl.gz",
@@ -109,14 +127,23 @@ class PPACorpusConfig(CorpusConfig):
 
 @dataclass
 class ConfigOpts:
+    """
+    Configuration options for compiling found poems dataset, loading
+    reference corpora, loading excerpts, and optional poem clusters metadata.
+    """
+
+    #: base directory
     base_dir: Path
+    #: directory for compiled found poems dataset
     compiled_dataset_dir: Path
+    #: PPA corpus configuration
     ppa_corpus: Optional[PPACorpusConfig] = None
+    #: reference corpus configurations
     reference_corpora: dict[str, CorpusConfig] = field(default_factory=dict)  # type: ignore[arg-type]
+    #: path to excerpt data to be included in compiled found poems dataset
     excerpt_data_dir: Optional[Path] = None
-    poem_clusters_path: Optional[str] = (
-        None  # currently expect a url rather than local path
-    )
+    #: path to poem clusters CSV; currently expects a URL rather than local path
+    poem_clusters_path: Optional[str] = None
 
     def __post_init__(self):
         self.excerpt_data_dir = resolve_path(self.excerpt_data_dir, self.base_dir)
@@ -126,7 +153,7 @@ class ConfigOpts:
 
 
 def get_config():
-    # if the config file is not in place
+    # complain if the config file is not in place
     if not CORPPA_CONFIG_PATH.exists():
         not_found_msg = (
             "Config file not found.\n"
@@ -183,7 +210,9 @@ def get_config():
             compiled_dataset_dir=Path(config_values["compiled_dataset_dir"]),
             ppa_corpus=ppa_corpus,
             reference_corpora=ref_corpus_configs,
-            excerpt_data_dir=config_values.get("excerpt_data_dir"),
+            excerpt_data_dir=resolve_path(
+                config_values.get("excerpt_data_dir"), base_dir
+            ),
             poem_clusters_path=config_values.get("poem_clusters_path"),
         )
     except KeyError as err:

--- a/src/corppa/config.py
+++ b/src/corppa/config.py
@@ -23,6 +23,9 @@ def resolve_path(path: str | Path | None, base_dir: Path) -> Path | None:
         return None
     if isinstance(path, str):
         path = Path(path)
+        # check for URL; don't make relative to base dir
+        if str(path).startswith("http"):
+            return path
     if not path.is_absolute() and not path.is_relative_to(base_dir):
         path = base_dir / path
     return path
@@ -67,6 +70,29 @@ class CorpusConfig:
         if self.metadata_path is None:
             self.metadata_path = f"{self.name}{self._path_suffix['metadata']}"
         self.metadata_path = resolve_path(self.metadata_path, self.base_dir)
+
+    def validate(self, text=True, metadata=True) -> bool:
+        if text:
+            if not self.text_path.exists():
+                raise ValueError(
+                    f"Configuration error: {self.name} path {self.text_path} does not exist"
+                )
+            # Currently supports directory and tar.gz file
+            if not self.text_path.is_dir() and not (
+                self.text_path.is_file() and self.text_path.name.endswith(".tar.gz")
+            ):
+                raise ValueError(
+                    f"Configuration error: {self.name} path {self.text_path} is not a directory or a tar.gz"
+                )
+        if metadata:
+            if not self.metadata_path.is_file() and not str(
+                self.metadata_path
+            ).startswith("http"):
+                raise ValueError(
+                    f"Configuration error: {self.name} metadata {self.metadata_path} does not exist"
+                )
+
+        return True
 
 
 @dataclass

--- a/src/corppa/poetry_detection/compile_dataset.py
+++ b/src/corppa/poetry_detection/compile_dataset.py
@@ -49,18 +49,18 @@ def load_compilation_config():
     validating that required configurations are present, paths exist, etc.
     """
     config_opts = get_config()
-    required_sections = ["compiled_dataset", "reference_corpora"]
-    for section in required_sections:
-        if section not in config_opts:
-            print(
-                f"Configuration error: '{section}' not found in config file",
-                file=sys.stderr,
-            )
-            sys.exit(-1)
+    # required_sections = ["compiled_dataset", "reference_corpora"]
+    # for section in required_sections:
+    #     if section not in config_opts:
+    #         print(
+    #             f"Configuration error: '{section}' not found in config file",
+    #             file=sys.stderr,
+    #         )
+    #         sys.exit(-1)
 
     # output directory
     try:
-        output_data_dir = pathlib.Path(config_opts["compiled_dataset"]["data_dir"])
+        output_data_dir = config_opts.compiled_dataset_dir
     except KeyError as err:
         raise ValueError(
             "Configuration error: config file requires `compiled_dataset.data_dir` path"
@@ -80,44 +80,46 @@ def load_compilation_config():
     poem_metadata_file = output_data_dir / "poem_meta.csv"
     ppa_metadata_file = output_data_dir / "ppa_work_metadata.csv"
 
-    # source directories
-    try:
-        source_base_dir = pathlib.Path(config_opts["data_ingredients_dir"])
-    except KeyError:
-        print(
-            "Configuration error: `data_ingredients_dir` not found in config file",
-            file=sys.stderr,
-        )
-        sys.exit(-1)
+    # # source directories
+    # try:
+    #     source_base_dir = pathlib.Path(config_opts["data_ingredients_dir"])
+    # except KeyError:
+    #     print(
+    #         "Configuration error: `data_ingredients_dir` not found in config file",
+    #         file=sys.stderr,
+    #     )
+    #     sys.exit(-1)
 
-    if not source_base_dir.exists():
-        raise ValueError(
-            f"Configuration error: compiled dataset source dir {source_base_dir} does not exist"
-        )
-    if not source_base_dir.is_dir():
-        raise ValueError(
-            f"Configuration error: compiled dataset source dir {source_base_dir} is not a directory"
-        )
+    # if not source_base_dir.exists():
+    #     raise ValueError(
+    #         f"Configuration error: compiled dataset source dir {source_base_dir} does not exist"
+    #     )
+    # if not source_base_dir.is_dir():
+    #     raise ValueError(
+    #         f"Configuration error: compiled dataset source dir {source_base_dir} is not a directory"
+    #     )
 
     # excerpt data dir - get from config if set
-    excerpt_data_dir = pathlib.Path(
-        config_opts["compiled_dataset"].get(
-            "source_excerpt_data", DEFAULT_CONFIGS["source_excerpt_data"]
-        )
-    )
+    excerpt_data_dir = config_opts.excerpt_data_dir
+    # pathlib.Path(
+    #     config_opts["compiled_dataset"].get(
+    #         "source_excerpt_data", DEFAULT_CONFIGS["source_excerpt_data"]
+    #     )
+    # )
     # if path is not absolute, make relative to source base directory
-    if not excerpt_data_dir.is_absolute():
-        excerpt_data_dir = source_base_dir / excerpt_data_dir
+    # if not excerpt_data_dir.is_absolute():
+    #     excerpt_data_dir = source_base_dir / excerpt_data_dir
 
     # ppa metadata
-    source_ppa_metadata = pathlib.Path(
-        config_opts["compiled_dataset"].get(
-            "source_ppa_metadata", DEFAULT_CONFIGS["source_ppa_metadata"]
-        )
-    )
+    source_ppa_metadata = config_opts.ppa_corpus.metadata_path
+    # source_ppa_metadata = pathlib.Path(
+    #     config_opts["compiled_dataset"].get(
+    #         "source_ppa_metadata", DEFAULT_CONFIGS["source_ppa_metadata"]
+    #     )
+    # )
     # if path is not absolute, make relative to source base directory
-    if not source_ppa_metadata.is_absolute():
-        source_ppa_metadata = source_base_dir / source_ppa_metadata
+    # if not source_ppa_metadata.is_absolute():
+    #     source_ppa_metadata = source_base_dir / source_ppa_metadata
     if not source_ppa_metadata.exists() or not source_ppa_metadata.is_file():
         raise ValueError(
             f"Configuration error: PPA metadata file {source_ppa_metadata} does not exist"
@@ -134,7 +136,7 @@ def load_compilation_config():
         "source_excerpt_data": excerpt_data_dir,
         "source_ppa_metadata": source_ppa_metadata,
         # required? warn?
-        "source_poem_clusters": config_opts["reference_corpora"]["poem_clusters_path"],
+        "source_poem_clusters": config_opts.poem_clusters_path,
     }
 
 

--- a/src/corppa/poetry_detection/compile_dataset.py
+++ b/src/corppa/poetry_detection/compile_dataset.py
@@ -249,11 +249,11 @@ def run_poem_metadata_step(
     else:
         excerpts_df = extract_page_meta(excerpts_df)
 
-    poem_clusters_df = (
-        pl.read_csv(compile_opts["source_poem_clusters"])
-        if compile_opts["source_poem_clusters"]
-        else None
-    )
+    # load poem cluster id information if configured
+    poem_cluster_path = compile_opts.get("source_poem_clusters")
+    poem_clusters_df = None
+    if poem_cluster_path:
+        poem_clusters_df = pl.read_csv(poem_cluster_path)
 
     save_poem_metadata(
         compile_opts["poem_metadata_file"], excerpts_df, poem_clusters_df

--- a/src/corppa/poetry_detection/compile_dataset.py
+++ b/src/corppa/poetry_detection/compile_dataset.py
@@ -49,22 +49,10 @@ def load_compilation_config():
     validating that required configurations are present, paths exist, etc.
     """
     config_opts = get_config()
-    # required_sections = ["compiled_dataset", "reference_corpora"]
-    # for section in required_sections:
-    #     if section not in config_opts:
-    #         print(
-    #             f"Configuration error: '{section}' not found in config file",
-    #             file=sys.stderr,
-    #         )
-    #         sys.exit(-1)
 
-    # output directory
-    try:
-        output_data_dir = config_opts.compiled_dataset_dir
-    except KeyError as err:
-        raise ValueError(
-            "Configuration error: config file requires `compiled_dataset.data_dir` path"
-        ) from err
+    # output directory - required in config object initialization
+    output_data_dir = config_opts.compiled_dataset_dir
+    # NOTE: could shift validation to config object in future
     if not output_data_dir.exists():
         raise ValueError(
             f"Configuration error: compiled dataset path {output_data_dir} does not exist"
@@ -75,51 +63,21 @@ def load_compilation_config():
         )
 
     # filenames where compiled data will be saved
+    # NOTE: perhaps in future this can be moved to a config object
     compiled_excerpt_file = output_data_dir / "excerpts.csv"
     compressed_excerpt_file = output_data_dir / "excerpts.csv.gz"
     poem_metadata_file = output_data_dir / "poem_meta.csv"
     ppa_metadata_file = output_data_dir / "ppa_work_metadata.csv"
 
-    # # source directories
-    # try:
-    #     source_base_dir = pathlib.Path(config_opts["data_ingredients_dir"])
-    # except KeyError:
-    #     print(
-    #         "Configuration error: `data_ingredients_dir` not found in config file",
-    #         file=sys.stderr,
-    #     )
-    #     sys.exit(-1)
-
-    # if not source_base_dir.exists():
-    #     raise ValueError(
-    #         f"Configuration error: compiled dataset source dir {source_base_dir} does not exist"
-    #     )
-    # if not source_base_dir.is_dir():
-    #     raise ValueError(
-    #         f"Configuration error: compiled dataset source dir {source_base_dir} is not a directory"
-    #     )
-
-    # excerpt data dir - get from config if set
+    # optional in config, but already resolved to base dir; validate existence?
     excerpt_data_dir = config_opts.excerpt_data_dir
-    # pathlib.Path(
-    #     config_opts["compiled_dataset"].get(
-    #         "source_excerpt_data", DEFAULT_CONFIGS["source_excerpt_data"]
-    #     )
-    # )
-    # if path is not absolute, make relative to source base directory
-    # if not excerpt_data_dir.is_absolute():
-    #     excerpt_data_dir = source_base_dir / excerpt_data_dir
 
-    # ppa metadata
+    # ppa metadata - optional in config, ensure it is present
+    if config_opts.ppa_corpus is None:
+        raise ValueError(
+            "Configuration error: PPA corpus must be configured for dataset compilation"
+        )
     source_ppa_metadata = config_opts.ppa_corpus.metadata_path
-    # source_ppa_metadata = pathlib.Path(
-    #     config_opts["compiled_dataset"].get(
-    #         "source_ppa_metadata", DEFAULT_CONFIGS["source_ppa_metadata"]
-    #     )
-    # )
-    # if path is not absolute, make relative to source base directory
-    # if not source_ppa_metadata.is_absolute():
-    #     source_ppa_metadata = source_base_dir / source_ppa_metadata
     if not source_ppa_metadata.exists() or not source_ppa_metadata.is_file():
         raise ValueError(
             f"Configuration error: PPA metadata file {source_ppa_metadata} does not exist"
@@ -135,7 +93,7 @@ def load_compilation_config():
         # sources
         "source_excerpt_data": excerpt_data_dir,
         "source_ppa_metadata": source_ppa_metadata,
-        # required? warn?
+        # required? warn if not present?
         "source_poem_clusters": config_opts.poem_clusters_path,
     }
 

--- a/src/corppa/poetry_detection/compile_dataset.py
+++ b/src/corppa/poetry_detection/compile_dataset.py
@@ -133,6 +133,8 @@ def load_compilation_config():
         # sources
         "source_excerpt_data": excerpt_data_dir,
         "source_ppa_metadata": source_ppa_metadata,
+        # required? warn?
+        "source_poem_clusters": config_opts["reference_corpora"]["poem_clusters_path"],
     }
 
 
@@ -246,7 +248,16 @@ def run_poem_metadata_step(
         excerpts_df = load_compiled_excerpts(compile_opts)
     else:
         excerpts_df = extract_page_meta(excerpts_df)
-    save_poem_metadata(compile_opts["poem_metadata_file"], excerpts_df)
+
+    poem_clusters_df = (
+        pl.read_csv(compile_opts["source_poem_clusters"])
+        if compile_opts["source_poem_clusters"]
+        else None
+    )
+
+    save_poem_metadata(
+        compile_opts["poem_metadata_file"], excerpts_df, poem_clusters_df
+    )
 
 
 def run_ppa_metadata_step(

--- a/src/corppa/poetry_detection/passim/run_passim.py
+++ b/src/corppa/poetry_detection/passim/run_passim.py
@@ -72,17 +72,19 @@ PassimOptions = namedtuple(
 )
 #: default options for running passim on PPA for poetry detection
 PASSIM_DEFAULTS = PassimOptions(ngram_size=15, min_align=25, gap=300, max_df=10_000)
+# NOTE: these differ from the current passim defaults, which are:
+#   ngram size 25, min align 50, gap 600, max df 100
 
 
 def run_passim(
     ppa_corpus: Path,
     ref_corpora: Iterable[Path],
     output_dir: Path,
-    max_df: int = PASSIM_DEFAULTS.max_df,  # was 100
+    max_df: int = PASSIM_DEFAULTS.max_df,
     min_match: int = 5,
-    ngram_size: int = PASSIM_DEFAULTS.ngram_size,  # was 25
-    gap: int = PASSIM_DEFAULTS.gap,  # was 600
-    min_align: int = PASSIM_DEFAULTS.min_align,  # was 50
+    ngram_size: int = PASSIM_DEFAULTS.ngram_size,
+    gap: int = PASSIM_DEFAULTS.gap,
+    min_align: int = PASSIM_DEFAULTS.min_align,
     floating_ngrams: bool = False,
     verbose: bool = False,
 ) -> bool:

--- a/src/corppa/poetry_detection/passim/run_passim.py
+++ b/src/corppa/poetry_detection/passim/run_passim.py
@@ -18,6 +18,7 @@ import argparse
 import os
 import re
 import sys
+from collections import namedtuple
 from collections.abc import Iterable
 from pathlib import Path
 from subprocess import CalledProcessError, run
@@ -66,15 +67,22 @@ def build_input_string(ppa_corpus: Path, ref_corpora: Iterable[Path]) -> str:
     return f"{{{','.join(map(str, corpus_files))}}}"
 
 
+PassimOptions = namedtuple(
+    "PassimOptions", ["ngram_size", "min_align", "gap", "max_df"]
+)
+#: default options for running passim on PPA for poetry detection
+PASSIM_DEFAULTS = PassimOptions(ngram_size=15, min_align=25, gap=300, max_df=10_000)
+
+
 def run_passim(
     ppa_corpus: Path,
     ref_corpora: Iterable[Path],
     output_dir: Path,
-    max_df: int = 100,
+    max_df: int = PASSIM_DEFAULTS.max_df,  # was 100
     min_match: int = 5,
-    ngram_size: int = 25,
-    gap: int = 600,
-    min_align: int = 50,
+    ngram_size: int = PASSIM_DEFAULTS.ngram_size,  # was 25
+    gap: int = PASSIM_DEFAULTS.gap,  # was 600
+    min_align: int = PASSIM_DEFAULTS.min_align,  # was 50
     floating_ngrams: bool = False,
     verbose: bool = False,
 ) -> bool:
@@ -156,7 +164,7 @@ def main():
         "--max-df",
         help="Passim parameter (maxDF): upper limit on document frequency",
         type=int,
-        default=10000,
+        default=PASSIM_DEFAULTS.max_df,  # 10k
     )
     parser.add_argument(
         "--min-match",
@@ -168,7 +176,7 @@ def main():
         "--ngram-size",
         help="Passim parameter (n): n-gram order",
         type=int,
-        default=15,
+        default=PASSIM_DEFAULTS.ngram_size,  # 15
     )
     parser.add_argument(
         "--floating-ngrams",
@@ -179,13 +187,13 @@ def main():
         "--gap",
         help="Passim parameter (gap): minimum size of gap that separates passage",
         type=int,
-        default=300,
+        default=PASSIM_DEFAULTS.gap,  # 300
     )
     parser.add_argument(
         "--min-align",
-        help="Passim paramaeter (min-align): minimum length of alignment",
+        help="Passim parameter (min-align): minimum length of alignment",
         type=int,
-        default=25,
+        default=PASSIM_DEFAULTS.min_align,  # 25
     )
     parser.add_argument("-v", "--verbose", action="store_true")
 

--- a/src/corppa/poetry_detection/polars_utils.py
+++ b/src/corppa/poetry_detection/polars_utils.py
@@ -41,6 +41,7 @@ POEM_FIELDS = {
     "num_lines": "poem_num_lines",
     "num_words": "poem_num_words",
     "char_len": "poem_char_len",
+    "cluster_id": "poem_cluster_id",
 }
 
 

--- a/src/corppa/poetry_detection/ref_corpora.py
+++ b/src/corppa/poetry_detection/ref_corpora.py
@@ -218,9 +218,8 @@ class OtherPoems(BaseReferenceCorpus):
     #: id for this reference corpus (currently "other")
     corpus_id: str = "other"
     corpus_name: str = "Other Poems"
+    #: config with metadata_path for URL or local path to metadata
     config: CorpusConfig
-    #: URL or local path for metadata (can pull from Google Sheets published csv)
-    # metadata_path: str
 
     def __init__(self, config_opts: CorpusConfig):
         # get configuration for this corpus

--- a/src/corppa/poetry_detection/ref_corpora.py
+++ b/src/corppa/poetry_detection/ref_corpora.py
@@ -163,7 +163,7 @@ class ChadwyckHealey(LocalTextCorpus):
     #: id for this reference corpus: chadwyck-healey
     corpus_id: str = "chadwyck-healey"
     corpus_name: str = "Chadwyck-Healey"
-    # inherits config with text_path &  metadata path
+    # inherits config with text_path & metadata path
 
     def get_metadata_df(self, poem_length=False) -> pl.DataFrame:
         # disable schema inference; the fields we care about are all strings

--- a/src/corppa/poetry_detection/ref_corpora.py
+++ b/src/corppa/poetry_detection/ref_corpora.py
@@ -78,17 +78,12 @@ class LocalTextCorpus(BaseReferenceCorpus):
     def get_text_corpus(
         self, disable_progress: bool = True
     ) -> Generator[dict[str, str]]:
-        # if text_path is tarball, raise not implemented error
-        if self.config.text_path is None:
-            raise ValueError(f"No text path configured for {self.corpus_id}")
+        # validation is now handled by CorpusConfig.validate
         if self.config.text_path.is_dir():
             corpus_method = build_text_corpus
         elif self.config.text_path.name.endswith(".tar.gz"):
             corpus_method = text_corpus_from_tarfile
-        else:
-            raise NotImplementedError(
-                "text corpus generation is only supported for tar.gz and directories"
-            )
+
         # build_text_corpus method returns id, so rename id to poem_id
         yield from (
             {"poem_id": p["id"], "text": p["text"]}

--- a/src/corppa/poetry_detection/ref_corpora.py
+++ b/src/corppa/poetry_detection/ref_corpora.py
@@ -103,8 +103,8 @@ class InternetPoems(LocalTextCorpus):
     the internet, for high priority sources known to occur in excerpts,
     including full text of Shakespeare's plays. Metadata was originally based on
     filename (naming convention of `Firstname-Lastname_Poem-Title.txt`),
-    but has since been augmented with wikidata information for poem authors.
-    The filename without extension is used as the `poem_id`.
+    but has since been converted to a CSV file for correction and augmentation.
+    The text filename without extension is used as the `poem_id`.
     """
 
     #: id for this reference corpus: internet_poems
@@ -139,7 +139,7 @@ class InternetPoems(LocalTextCorpus):
     def get_metadata_from_files(self, poem_length=False) -> pl.DataFrame:
         metadata = []
         # returns a generator of dicts with id and text string
-        # TODO: when called from compile script, might be nice to show progress bar
+        # NOTE: when called from compile script, might be nice to show progress bar
         for poem in self.get_text_corpus():
             # filename format:
             #   Firstname-Lastname_Poem-Title.txt
@@ -191,7 +191,6 @@ class ChadwyckHealey(LocalTextCorpus):
 
         if poem_length:
             poem_lengths = []
-
             # text corpus returns a generator of dicts with id and text string
             # NOTE: when called from compile script, might be nice to show progress bar
             for poem in self.get_text_corpus():
@@ -283,7 +282,14 @@ def save_poem_metadata(
     poem_clusters_df: Optional[pl.DataFrame] = None,
 ):
     """Generate and save compiled poetry metadata as a data file in the
-    poem dataset.
+    poem dataset. Loads and compiles metadata for all reference corpora,
+    including poem length calculations (:meth:`compile_metadata_df`)
+    and saves the result to the specified `output_file`.  When the optional
+    `excerpts_df` is present, calculates work-level excerpt total for poems
+    based on primary poem id (number of excerpts, number of PPA works,
+    number of PPA pages).  When the optional `poem_clusters_df` is provided,
+    adds a `cluster_id` field to poems known to be duplicates, near-duplicates
+    or subsets.
     """
     # check & report if the file already exists
     output_verb = "Creating"

--- a/src/corppa/poetry_detection/ref_corpora.py
+++ b/src/corppa/poetry_detection/ref_corpora.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 import polars as pl
 
-from corppa.config import get_config
+from corppa.config import CorpusConfig, get_config
 from corppa.utils.build_text_corpus import build_text_corpus, text_corpus_from_tarfile
 
 logger = logging.getLogger(__name__)
@@ -31,40 +31,7 @@ class BaseReferenceCorpus:
 
     corpus_id: str
     corpus_name: str
-    text_path: pathlib.Path
-    metadata_path: pathlib.Path | str
-
-    def get_config_opts(self) -> dict:
-        """Load reference corpus-specific configuration options from
-        corppa config file. Must include the reference corpora base directory;
-        may include overrides for non-default paths.
-        """
-        config_opts = get_config()
-        if "reference_corpora" not in config_opts:
-            raise ValueError(
-                "Configuration error: required section 'reference_corpora' not found"
-            )
-        try:
-            base_dir = pathlib.Path(config_opts["reference_corpora"]["base_dir"])
-        except KeyError:
-            raise ValueError(
-                "Configuration error: required 'reference_corpora.base_dir' not found"
-            )
-        # always include the reference_corpora base directory as a path
-        # if not absolute, path is relative to data ingredients dir
-        if not base_dir.is_absolute():
-            try:
-                ingredients_dir = pathlib.Path(config_opts["data_ingredients_dir"])
-            except KeyError:
-                raise ValueError(
-                    "Configuration error: 'reference_corpora.base_dir' is relative but 'data_ingredients_dir' is not configured"
-                )
-            base_dir = ingredients_dir / base_dir
-
-        corpus_opts = {"base_dir": base_dir}
-        # include any options for this specific corpus
-        corpus_opts.update(config_opts["reference_corpora"].get(self.corpus_id, {}))
-        return corpus_opts
+    config: CorpusConfig
 
     @staticmethod
     def calculate_poem_length(text: str) -> dict[str, int]:
@@ -97,52 +64,56 @@ class LocalTextCorpus(BaseReferenceCorpus):
     """Base class for reference corpus where text content is
     provided as a set of text files in a directory or tar.gz.
     On initialization, configures data path based on
-    configured based dir and corpus default or any overrides, and validates
+    configured base dir and corpus default or any overrides, and validates
     that the path exists and is a directory.
     Provides :meth:`get_text_corpus` for generating text corpus from
     the file system."""
 
-    def __init__(self):
-        # get configuration for this corpus
-        config_opts = self.get_config_opts()
+    def __init__(self, config_opts: CorpusConfig):
+        # get text directory for this reference corpus from corpus configuration
+        self.config = config_opts
 
-        # get text directory for this reference corpus from app configuration
-        if "text_path" in config_opts:
-            self.text_path = pathlib.Path(config_opts["text_path"])
-        # if text path is not absolute, assume relative to ref_corpus base dir
-        # TODO: shift relative path logic to config loader
-        if not self.text_path.is_absolute():
-            self.text_path = config_opts["base_dir"] / self.text_path
+        # TODO: move validation logic to config class
 
-        if not self.text_path.exists():
-            raise ValueError(
-                f"Configuration error: {self.corpus_name} path {self.text_path} does not exist"
-            )
-        # Currently supports directory and tar.gz file;
-        # might be nice to support zipfile as well
-        if not self.text_path.is_dir() and not (
-            self.text_path.is_file() and self.text_path.name.endswith(".tar.gz")
-        ):
-            raise ValueError(
-                f"Configuration error: {self.corpus_name} path {self.text_path} is not a directory or a tar.gz"
-            )
+        # self.text_path = pathlib.Path(config_opts["text_path"])
+        # # if text path is not absolute, assume relative to ref_corpus base dir
+        # # TODO: shift relative path logic to config loader
+        # if not self.text_path.is_absolute():
+        #     self.text_path = config_opts["base_dir"] / self.text_path
 
-        # set metadata path if present in configuration
-        if "metadata_path" in config_opts:
-            self.metadata_path = pathlib.Path(config_opts["metadata_path"])
-            # if metadata path is not absolute, assume relative to ref_corpus base dir
-            if not self.metadata_path.is_absolute():
-                self.metadata_path = config_opts["base_dir"] / self.metadata_path
-            if not (self.metadata_path.exists() and self.metadata_path.is_file()):
-                raise ValueError(
-                    f"Configuration error: {self.corpus_name} metadata {self.metadata_path} does not exist"
-                )
+        # if not self.text_path.exists():
+        #     raise ValueError(
+        #         f"Configuration error: {self.corpus_name} path {self.text_path} does not exist"
+        #     )
+        # # Currently supports directory and tar.gz file;
+        # # might be nice to support zipfile as well
+        # if not self.text_path.is_dir() and not (
+        #     self.text_path.is_file() and self.text_path.name.endswith(".tar.gz")
+        # ):
+        #     raise ValueError(
+        #         f"Configuration error: {self.corpus_name} path {self.text_path} is not a directory or a tar.gz"
+        #     )
 
-    def get_text_corpus(self, disable_progress: bool = True) -> dict[str, str]:
+        # # set metadata path if present in configuration
+        # if "metadata_path" in config_opts:
+        #     self.metadata_path = pathlib.Path(config_opts["metadata_path"])
+        #     # if metadata path is not absolute, assume relative to ref_corpus base dir
+        #     if not self.metadata_path.is_absolute():
+        #         self.metadata_path = config_opts["base_dir"] / self.metadata_path
+        #     if not (self.metadata_path.exists() and self.metadata_path.is_file()):
+        #         raise ValueError(
+        #             f"Configuration error: {self.corpus_name} metadata {self.metadata_path} does not exist"
+        #         )
+
+    def get_text_corpus(
+        self, disable_progress: bool = True
+    ) -> Generator[dict[str, str]]:
         # if text_path is tarball, raise not implemented error
-        if self.text_path.is_dir():
+        if self.config.text_path is None:
+            raise ValueError(f"No text path configured for {self.corpus_id}")
+        if self.config.text_path.is_dir():
             corpus_method = build_text_corpus
-        elif self.text_path.name.endswith(".tar.gz"):
+        elif self.config.text_path.name.endswith(".tar.gz"):
             corpus_method = text_corpus_from_tarfile
         else:
             raise NotImplementedError(
@@ -151,7 +122,9 @@ class LocalTextCorpus(BaseReferenceCorpus):
         # build_text_corpus method returns id, so rename id to poem_id
         yield from (
             {"poem_id": p["id"], "text": p["text"]}
-            for p in corpus_method(self.text_path, disable_progress=disable_progress)
+            for p in corpus_method(
+                self.config.text_path, disable_progress=disable_progress
+            )
         )
 
 
@@ -167,15 +140,33 @@ class InternetPoems(LocalTextCorpus):
     #: id for this reference corpus: internet_poems
     corpus_id: str = "internet_poems"
     corpus_name: str = "Internet Poems"
-    # inherits text_path
+    # inherits config with text_path
 
     # no init/validation needed beyond that provided by LocalTextCorpus
 
     def get_metadata_df(self, poem_length=False) -> pl.DataFrame:
-        # TODO: what to do about WH's metadata? connect / replace / separate
-        # if self.metadata_path:
-        #     df = pl.read_csv(self.metadata_path, infer_schema=False)
+        if (
+            self.config.metadata_path is not None
+            and self.config.metadata_path.is_file()
+        ):
+            # load metadata and add reference corpus id
+            df = pl.read_csv(
+                self.config.metadata_path, schema_overrides=METADATA_SCHEMA
+            ).with_columns(ref_corpus=pl.lit(self.corpus_id))
+            # if poem length is requested, get from the files and add to df
+            if poem_length:
+                length_df = self.get_metadata_from_files(poem_length=poem_length)
+                df = df.join(
+                    length_df.select("poem_id", "num_lines", "num_words", "char_len"),
+                    on="poem_id",
+                )
+        else:
+            # fallback metadata: generate from filenames
+            df = self.get_metadata_from_files(poem_length=poem_length)
 
+        return df
+
+    def get_metadata_from_files(self, poem_length=False) -> pl.DataFrame:
         metadata = []
         # returns a generator of dicts with id and text string
         # TODO: when called from compile script, might be nice to show progress bar
@@ -207,13 +198,13 @@ class ChadwyckHealey(LocalTextCorpus):
     #: id for this reference corpus: chadwyck-healey
     corpus_id: str = "chadwyck-healey"
     corpus_name: str = "Chadwyck-Healey"
-    # inherits text_path &  metadata path
+    # inherits config with text_path &  metadata path
 
     def get_metadata_df(self, poem_length=False) -> pl.DataFrame:
         # disable schema inference; the fields we care about are all strings
         # TODO: check / update for revised metadata
         df = (
-            pl.read_csv(self.metadata_path, infer_schema=False)
+            pl.read_csv(self.config.metadata_path, infer_schema=False)
             # rename fields
             .rename({"title_main": "title", "id": "poem_id"})
             # construct author name from separate fields in the metadata
@@ -263,25 +254,26 @@ class OtherPoems(BaseReferenceCorpus):
     #: id for this reference corpus (currently "other")
     corpus_id: str = "other"
     corpus_name: str = "Other Poems"
+    config: CorpusConfig
     #: URL or local path for metadata (can pull from Google Sheets published csv)
-    metadata_path: str
+    # metadata_path: str
 
-    def __init__(self):
+    def __init__(self, config_opts: CorpusConfig):
         # get configuration for this corpus
-        config_opts = self.get_config_opts()
+        self.config = config_opts
         # set data path from config file and check that path exists
-        try:
-            self.metadata_path = config_opts["metadata_path"]
-        except KeyError:
-            raise ValueError(
-                f"Configuration error: {self.corpus_name} 'metadata_path' is not set"
-            )
+        # try:
+        #     self.metadata_path = config_opts["metadata_path"]
+        # except KeyError:
+        #     raise ValueError(
+        #         f"Configuration error: {self.corpus_name} 'metadata_path' is not set"
+        #     )
 
     def get_metadata_df(self, poem_length=False) -> pl.DataFrame:
         # polars can load csv directly from a url
-        return pl.read_csv(self.metadata_path, schema=METADATA_SCHEMA).with_columns(
-            ref_corpus=pl.lit(self.corpus_id)
-        )
+        return pl.read_csv(
+            self.config.metadata_path, schema=METADATA_SCHEMA
+        ).with_columns(ref_corpus=pl.lit(self.corpus_id))
 
     # this is a metadata-only corpus; get_text_corpus is intentionally not implemented
 
@@ -289,13 +281,22 @@ class OtherPoems(BaseReferenceCorpus):
 def all_corpora() -> list[BaseReferenceCorpus]:
     """Convenience access to all reference corpora, for generating
     compiled versions of reference data."""
-    return [InternetPoems(), ChadwyckHealey(), OtherPoems()]
+    config = get_config()
+    return [
+        InternetPoems(config.reference_corpora["internet_poems"]),
+        ChadwyckHealey(config.reference_corpora["chadwyck-healey"]),
+        OtherPoems(config.reference_corpora["other_poems"]),
+    ]
 
 
 def fulltext_corpora() -> list[BaseReferenceCorpus]:
     """Convenience access to all full-text reference corpora, for generating
     compiled metadata and text."""
-    return [InternetPoems(), ChadwyckHealey()]
+    config = get_config()
+    return [
+        InternetPoems(config.reference_corpora["internet_poems"]),
+        ChadwyckHealey(config.reference_corpora["chadwyck-healey"]),
+    ]
 
 
 def compile_metadata_df(poem_length=False) -> pl.DataFrame:

--- a/src/corppa/poetry_detection/ref_corpora.py
+++ b/src/corppa/poetry_detection/ref_corpora.py
@@ -357,9 +357,12 @@ def save_poem_metadata(
         df = df.join(
             poem_clusters_df.select("poem_id", "cluster_id"), on="poem_id", how="left"
         )
-        n_with_cluster_ids = df.filter(pl.col.cluster_id.is_not_null()).height
+        # report on cluster ids and number of unique clusters (don't include nulls)
+        df_with_cluster_ids = df.filter(pl.col.cluster_id.is_not_null())
+        n_with_cluster_ids = df_with_cluster_ids.height
+        n_uniq_clusters = df_with_cluster_ids["cluster_id"].n_unique()
         print(
-            f"{n_with_cluster_ids:,} poems with cluster ids ({df['cluster_id'].n_unique():,} unique clusters)"
+            f"{n_with_cluster_ids:,} poems with cluster ids ({n_uniq_clusters:,} unique cluster{'s' if n_uniq_clusters != 1 else ''})"
         )
 
     print(f"{df.height:,} poem metadata entries ({'; '.join(totals)})")

--- a/src/corppa/poetry_detection/ref_corpora.py
+++ b/src/corppa/poetry_detection/ref_corpora.py
@@ -72,38 +72,8 @@ class LocalTextCorpus(BaseReferenceCorpus):
     def __init__(self, config_opts: CorpusConfig):
         # get text directory for this reference corpus from corpus configuration
         self.config = config_opts
-
-        # TODO: move validation logic to config class
-
-        # self.text_path = pathlib.Path(config_opts["text_path"])
-        # # if text path is not absolute, assume relative to ref_corpus base dir
-        # # TODO: shift relative path logic to config loader
-        # if not self.text_path.is_absolute():
-        #     self.text_path = config_opts["base_dir"] / self.text_path
-
-        # if not self.text_path.exists():
-        #     raise ValueError(
-        #         f"Configuration error: {self.corpus_name} path {self.text_path} does not exist"
-        #     )
-        # # Currently supports directory and tar.gz file;
-        # # might be nice to support zipfile as well
-        # if not self.text_path.is_dir() and not (
-        #     self.text_path.is_file() and self.text_path.name.endswith(".tar.gz")
-        # ):
-        #     raise ValueError(
-        #         f"Configuration error: {self.corpus_name} path {self.text_path} is not a directory or a tar.gz"
-        #     )
-
-        # # set metadata path if present in configuration
-        # if "metadata_path" in config_opts:
-        #     self.metadata_path = pathlib.Path(config_opts["metadata_path"])
-        #     # if metadata path is not absolute, assume relative to ref_corpus base dir
-        #     if not self.metadata_path.is_absolute():
-        #         self.metadata_path = config_opts["base_dir"] / self.metadata_path
-        #     if not (self.metadata_path.exists() and self.metadata_path.is_file()):
-        #         raise ValueError(
-        #             f"Configuration error: {self.corpus_name} metadata {self.metadata_path} does not exist"
-        #         )
+        # validate config file; for text-only corpus, metadata is optional
+        self.config.validate(metadata=False)
 
     def get_text_corpus(
         self, disable_progress: bool = True
@@ -261,13 +231,8 @@ class OtherPoems(BaseReferenceCorpus):
     def __init__(self, config_opts: CorpusConfig):
         # get configuration for this corpus
         self.config = config_opts
-        # set data path from config file and check that path exists
-        # try:
-        #     self.metadata_path = config_opts["metadata_path"]
-        # except KeyError:
-        #     raise ValueError(
-        #         f"Configuration error: {self.corpus_name} 'metadata_path' is not set"
-        #     )
+        # validate configuration - metadata only
+        self.config.validate(text=False)
 
     def get_metadata_df(self, poem_length=False) -> pl.DataFrame:
         # polars can load csv directly from a url

--- a/src/corppa/poetry_detection/ref_corpora.py
+++ b/src/corppa/poetry_detection/ref_corpora.py
@@ -127,6 +127,17 @@ class LocalTextCorpus(BaseReferenceCorpus):
                 f"Configuration error: {self.corpus_name} path {self.text_path} is not a directory or a tar.gz"
             )
 
+        # set metadata path if present in configuration
+        if "metadata_path" in config_opts:
+            self.metadata_path = pathlib.Path(config_opts["metadata_path"])
+            # if metadata path is not absolute, assume relative to ref_corpus base dir
+            if not self.metadata_path.is_absolute():
+                self.metadata_path = config_opts["base_dir"] / self.metadata_path
+            if not (self.metadata_path.exists() and self.metadata_path.is_file()):
+                raise ValueError(
+                    f"Configuration error: {self.corpus_name} metadata {self.metadata_path} does not exist"
+                )
+
     def get_text_corpus(self, disable_progress: bool = True) -> dict[str, str]:
         # if text_path is tarball, raise not implemented error
         if self.text_path.is_dir():
@@ -147,8 +158,9 @@ class LocalTextCorpus(BaseReferenceCorpus):
 class InternetPoems(LocalTextCorpus):
     """Curated corpus of poems with plain text content sourced from
     the internet, for high priority sources known to occur in excerpts,
-    including full text of Shakespeare's plays. Metadata is inferred based on
-    filename, with a naming convention of `Firstname-Lastname_Poem-Title.txt`.
+    including full text of Shakespeare's plays. Metadata was originally based on
+    filename (naming convention of `Firstname-Lastname_Poem-Title.txt`),
+    but has since been augmented with wikidata information for poem authors.
     The filename without extension is used as the `poem_id`.
     """
 
@@ -160,6 +172,10 @@ class InternetPoems(LocalTextCorpus):
     # no init/validation needed beyond that provided by LocalTextCorpus
 
     def get_metadata_df(self, poem_length=False) -> pl.DataFrame:
+        # TODO: what to do about WH's metadata? connect / replace / separate
+        # if self.metadata_path:
+        #     df = pl.read_csv(self.metadata_path, infer_schema=False)
+
         metadata = []
         # returns a generator of dicts with id and text string
         # TODO: when called from compile script, might be nice to show progress bar
@@ -191,25 +207,11 @@ class ChadwyckHealey(LocalTextCorpus):
     #: id for this reference corpus: chadwyck-healey
     corpus_id: str = "chadwyck-healey"
     corpus_name: str = "Chadwyck-Healey"
-    # inherits text_path
-
-    def __init__(self):
-        # use LocalTextCorpus init to configure and validate text_path
-        super().__init__()
-        # get configuration to set metadata path
-        config_opts = self.get_config_opts()
-
-        self.metadata_path = pathlib.Path(config_opts["metadata_path"])
-        # if metadata path is not absolute, assume relative to ref_corpus base dir
-        if not self.metadata_path.is_absolute():
-            self.metadata_path = config_opts["base_dir"] / self.metadata_path
-        if not (self.metadata_path.exists() and self.metadata_path.is_file()):
-            raise ValueError(
-                f"Configuration error: {self.corpus_name} metadata {self.metadata_path} does not exist"
-            )
+    # inherits text_path &  metadata path
 
     def get_metadata_df(self, poem_length=False) -> pl.DataFrame:
         # disable schema inference; the fields we care about are all strings
+        # TODO: check / update for revised metadata
         df = (
             pl.read_csv(self.metadata_path, infer_schema=False)
             # rename fields
@@ -310,7 +312,9 @@ def compile_metadata_df(poem_length=False) -> pl.DataFrame:
 
 
 def save_poem_metadata(
-    output_file: pathlib.Path, excerpts_df: Optional[pl.DataFrame] = None
+    output_file: pathlib.Path,
+    excerpts_df: Optional[pl.DataFrame] = None,
+    poem_clusters_df: Optional[pl.DataFrame] = None,
 ):
     """Generate and save compiled poetry metadata as a data file in the
     poem dataset.
@@ -348,6 +352,14 @@ def save_poem_metadata(
             pl.col("num_excerpts").fill_null(pl.lit(0)),
             pl.col("num_ppa_works").fill_null(pl.lit(0)),
             pl.col("num_ppa_pages").fill_null(pl.lit(0)),
+        )
+    if poem_clusters_df is not None:
+        df = df.join(
+            poem_clusters_df.select("poem_id", "cluster_id"), on="poem_id", how="left"
+        )
+        n_with_cluster_ids = df.filter(pl.col.cluster_id.is_not_null()).height
+        print(
+            f"{n_with_cluster_ids:,} poems with cluster ids ({df['cluster_id'].n_unique():,} unique clusters)"
         )
 
     print(f"{df.height:,} poem metadata entries ({'; '.join(totals)})")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -65,7 +65,7 @@ compiled_dataset_dir: "/tmp/p-p-poems/data"
         assert config_opts.compiled_dataset_dir == Path("/tmp/p-p-poems/data")
         # other items are unset
         assert config_opts.ppa_corpus is None
-        assert config_opts.reference_corpora == []
+        assert config_opts.reference_corpora == {}
 
 
 def test_get_config_defaults(tmp_path):
@@ -85,7 +85,7 @@ reference_corpora:
     with patch.object(config, "CORPPA_CONFIG_PATH", new=test_config):
         config_opts = config.get_config()
         assert len(config_opts.reference_corpora) == 1
-        ch_config = config_opts.reference_corpora[0]
+        ch_config = config_opts.reference_corpora["chadwyck-healey"]
         assert ch_config.text_path == Path(override_text_dir)
 
 
@@ -108,11 +108,15 @@ reference_corpora:
         assert config_opts.compiled_dataset_dir == Path("data/found-poems")
         assert config_opts.poem_clusters_path == "http://example.com/poem_groups.csv"
         assert len(config_opts.reference_corpora) == 3
-        assert [rc.name for rc in config_opts.reference_corpora] == [
+        ref_corpora_names = [
             "chadwyck-healey",
             "internet_poems",
             "other_poems",
         ]
+        assert list(config_opts.reference_corpora.keys()) == ref_corpora_names
+        assert [
+            rc.name for rc in config_opts.reference_corpora.values()
+        ] == ref_corpora_names
 
 
 ## test dataclass config objects

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -90,13 +90,14 @@ reference_corpora:
 
 
 def test_get_config_maximal(tmp_path):
-    # create a test config file with one section and one value
+    # create and check a test config file with all possible values
     test_config = tmp_path / "test.cfg"
-    test_config.write_text("""
+    poem_cluster_url = "http://example.com/poem_groups.csv"
+    test_config.write_text(f"""
 base_dir: data/
 compiled_dataset_dir: found-poems/
 excerpt_data_dir: excerpt-data/
-poem_clusters_path: http://example.com/poem_groups.csv
+poem_clusters_path: {poem_cluster_url}
 ppa_corpus:
   base_dir: ppa-corpus
 reference_corpora:
@@ -108,8 +109,11 @@ reference_corpora:
     # use patch to override the config path and load our test file
     with patch.object(config, "CORPPA_CONFIG_PATH", new=test_config):
         config_opts = config.get_config()
-        assert config_opts.compiled_dataset_dir == Path("data/found-poems")
+        # compiled dataset dir should not be resolved relative to base dir
+        assert not config_opts.compiled_dataset_dir.is_relative_to(config_opts.base_dir)
         assert config_opts.poem_clusters_path == "http://example.com/poem_groups.csv"
+        assert config_opts.excerpt_data_dir == Path("data/excerpt-data")
+        assert config_opts.poem_clusters_path == poem_cluster_url
         assert len(config_opts.reference_corpora) == 3
         ref_corpora_names = [
             "chadwyck-healey",
@@ -220,7 +224,7 @@ class TestCorpusConfig:
         # text file only
         ref_corpus.base_dir.mkdir()
         ref_corpus.text_path.touch()
-        # text-only validation should pass
+        # text-only validation should pass without error
         assert ref_corpus.validate(metadata=False)
         # text and metadata should fail
         with pytest.raises(ValueError):
@@ -235,7 +239,7 @@ class TestCorpusConfig:
         # metadata only should pass
         assert ref_corpus.validate(text=False)
         # text and metadata should fail
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="does not exist"):
             ref_corpus.validate()
 
         # wrong kind of text file
@@ -250,6 +254,21 @@ class TestCorpusConfig:
             ValueError, match=f"Configuration error: {corpus_id} text_path is not set"
         ):
             ref_corpus.validate()
+
+        # metadata_path set to None (shouldn't happen normally)
+        ref_corpus.metadata_path = None
+        with pytest.raises(
+            ValueError,
+            match=f"Configuration error: {corpus_id} metadata_path is not set",
+        ):
+            ref_corpus.validate(text=False)
+        # similar for empty string
+        ref_corpus.metadata_path = ""
+        with pytest.raises(
+            ValueError,
+            match=f"Configuration error: {corpus_id} metadata_path is not set",
+        ):
+            ref_corpus.validate(text=False)
 
     def test_metadata_url(self):
         metadata_url = "http://example.com/poetry/metadata.csv"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -97,7 +97,10 @@ base_dir: data/
 compiled_dataset_dir: found-poems/
 excerpt_data_dir: excerpt-data/
 poem_clusters_path: http://example.com/poem_groups.csv
+ppa_corpus:
+  base_dir: ppa-corpus
 reference_corpora:
+    base_dir: refs
     chadwyck-healey:
     internet_poems:
     other_poems:
@@ -120,6 +123,11 @@ reference_corpora:
         assert all(
             rc.base_dir.is_relative_to(config_opts.base_dir)
             for rc in ref_corpus_configs
+        )
+        # should be relative to top-level ref corus dir
+        ref_corpus_dir = config_opts.base_dir / "refs"
+        assert all(
+            rc.base_dir.is_relative_to(ref_corpus_dir) for rc in ref_corpus_configs
         )
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -195,3 +195,40 @@ class TestCorpusConfig:
         # default file names
         assert ppa_corpus.text_path == base_dir / "ppa_pages.jsonl.gz"
         assert ppa_corpus.metadata_path == base_dir / "ppa_metadata.csv"
+
+    def test_vaidate(self, tmp_path):
+        # specifying corpus name is enough to set defaults for the rest
+        ref_corpus = config.CorpusConfig(
+            name="test",
+            base_dir=tmp_path / "foo",
+        )
+        # neither text nor metadata exists
+        with pytest.raises(ValueError):
+            ref_corpus.validate()
+
+        # text file only
+        ref_corpus.base_dir.mkdir()
+        ref_corpus.text_path.touch()
+        # text-only validation should pass
+        assert ref_corpus.validate(metadata=False)
+        # text and metadata should fail
+        with pytest.raises(ValueError):
+            ref_corpus.validate()
+
+        # both text and metadata files present
+        ref_corpus.metadata_path.touch()
+        assert ref_corpus.validate()
+
+        # metadata only
+        ref_corpus.text_path.unlink()
+        # metadata only should pass
+        assert ref_corpus.validate(text=False)
+        # text and metadata should fail
+        with pytest.raises(ValueError):
+            ref_corpus.validate()
+
+        # wrong kind of text file
+        ref_corpus.text_path = ref_corpus.base_dir / "text_files.zip"
+        ref_corpus.text_path.touch()
+        with pytest.raises(ValueError):
+            ref_corpus.validate()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -196,7 +196,7 @@ class TestCorpusConfig:
         assert ppa_corpus.text_path == base_dir / "ppa_pages.jsonl.gz"
         assert ppa_corpus.metadata_path == base_dir / "ppa_metadata.csv"
 
-    def test_vaidate(self, tmp_path):
+    def test_validate(self, tmp_path):
         # specifying corpus name is enough to set defaults for the rest
         ref_corpus = config.CorpusConfig(
             name="test",
@@ -232,3 +232,11 @@ class TestCorpusConfig:
         ref_corpus.text_path.touch()
         with pytest.raises(ValueError):
             ref_corpus.validate()
+
+    def test_metadata_url(self):
+        metadata_url = "http://example.com/poetry/metadata.csv"
+        online_corpus = config.CorpusConfig(name="online", metadata_path=metadata_url)
+        # url should not be modified
+        assert online_corpus.metadata_path == metadata_url
+        # should not be considered invalid
+        assert online_corpus.validate(text=False)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -198,8 +198,9 @@ class TestCorpusConfig:
 
     def test_validate(self, tmp_path):
         # specifying corpus name is enough to set defaults for the rest
+        corpus_id = "text_corpus"
         ref_corpus = config.CorpusConfig(
-            name="test",
+            name=corpus_id,
             base_dir=tmp_path / "foo",
         )
         # neither text nor metadata exists
@@ -231,6 +232,13 @@ class TestCorpusConfig:
         ref_corpus.text_path = ref_corpus.base_dir / "text_files.zip"
         ref_corpus.text_path.touch()
         with pytest.raises(ValueError):
+            ref_corpus.validate()
+
+        # text path set to None (shouldn't happen normally)
+        ref_corpus.text_path = None
+        with pytest.raises(
+            ValueError, match=f"Configuration error: {corpus_id} text_path is not set"
+        ):
             ref_corpus.validate()
 
     def test_metadata_url(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -124,11 +124,13 @@ reference_corpora:
             rc.base_dir.is_relative_to(config_opts.base_dir)
             for rc in ref_corpus_configs
         )
-        # should be relative to top-level ref corus dir
+        # should be relative to top-level ref corpus dir
         ref_corpus_dir = config_opts.base_dir / "refs"
         assert all(
             rc.base_dir.is_relative_to(ref_corpus_dir) for rc in ref_corpus_configs
         )
+        # ppa dir relative to top-level base_dir
+        assert config_opts.ppa_corpus.base_dir == config_opts.base_dir / "ppa-corpus"
 
 
 ## test module-level helpers

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,4 @@
-tests / test_config.py  # Copyright (c) 2024-2026, Center for Digital Humanities, Princeton University
+# Copyright (c) 2024-2026, Center for Digital Humanities, Princeton University
 # SPDX-License-Identifier: Apache-2.0
 
 from pathlib import Path
@@ -114,9 +114,13 @@ reference_corpora:
             "other_poems",
         ]
         assert list(config_opts.reference_corpora.keys()) == ref_corpora_names
-        assert [
-            rc.name for rc in config_opts.reference_corpora.values()
-        ] == ref_corpora_names
+        ref_corpus_configs = config_opts.reference_corpora.values()
+        assert [rc.name for rc in ref_corpus_configs] == ref_corpora_names
+        # all ref-corpus base directories should be relative to base dir
+        assert all(
+            rc.base_dir.is_relative_to(config_opts.base_dir)
+            for rc in ref_corpus_configs
+        )
 
 
 ## test module-level helpers

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,24 +1,12 @@
-# Copyright (c) 2024-2025, Center for Digital Humanities, Princeton University
+# Copyright (c) 2024-2026, Center for Digital Humanities, Princeton University
 # SPDX-License-Identifier: Apache-2.0
 
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
 from corppa import config
-
-
-def test_merge_dicts():
-    # no nesting, no conflict
-    assert config.merge_dicts({"a": 1}, {"b": 2}) == {"a": 1, "b": 2}
-    # no nesting; second overrides first
-    assert config.merge_dicts({"a": 1}, {"a": 2}) == {"a": 2}
-    # nesting, no conflict
-    assert config.merge_dicts({"a": {"b": 1}}, {"a": {"c": 2}}) == {
-        "a": {"b": 1, "c": 2}
-    }
-    # nesting, with override
-    assert config.merge_dicts({"a": {"b": 1}}, {"a": {"b": 2}}) == {"a": {"b": 2}}
 
 
 def test_get_config_not_found(tmp_path):
@@ -44,19 +32,40 @@ data_dir=/tmp/p-p-poems/data
             config.get_config()
 
 
+def test_get_config_missing_required(tmp_path):
+    test_config = tmp_path / "test.cfg"
+    test_config.write_text("foo: bar")
+    with patch.object(config, "CORPPA_CONFIG_PATH", new=test_config):
+        with pytest.raises(
+            SystemExit, match="missing required configuration: base_dir"
+        ):
+            config.get_config()
+
+        # if first required field is present, should error on the next one
+        test_config.write_text("base_dir: /tmp/data/")
+        with pytest.raises(
+            SystemExit, match="missing required configuration: compiled_dataset_dir"
+        ):
+            config.get_config()
+
+
 def test_get_config(tmp_path):
     # create a test config file with one section and one value
     test_config = tmp_path / "test.cfg"
     test_config.write_text("""
+base_dir: data/
 # local path to compiled poem dataset files
-compiled_dataset:
-  text_dir: "/tmp/p-p-poems/data"
+compiled_dataset_dir: "/tmp/p-p-poems/data"
 """)
     # use patch to override the config path and load our test file
     with patch.object(config, "CORPPA_CONFIG_PATH", new=test_config):
         config_opts = config.get_config()
-        assert "compiled_dataset" in config_opts
-        assert config_opts["compiled_dataset"]["text_dir"] == "/tmp/p-p-poems/data"
+        assert isinstance(config_opts, config.ConfigOpts)
+        assert config_opts.base_dir == Path("data")
+        assert config_opts.compiled_dataset_dir == Path("/tmp/p-p-poems/data")
+        # other items are unset
+        assert config_opts.ppa_corpus is None
+        assert config_opts.reference_corpora == []
 
 
 def test_get_config_defaults(tmp_path):
@@ -65,19 +74,89 @@ def test_get_config_defaults(tmp_path):
     # override one portion of a nested config
     override_text_dir = "/ch/text.tar.gz"
     test_config.write_text(f"""
+base_dir: data/
+compiled_dataset_dir: found-poems/
 # local path to compiled poem dataset files
 reference_corpora:
     chadwyck-healey:
-        text_dir: "{override_text_dir}"
+        text_path: "{override_text_dir}"
 """)
     # use patch to override the config path and load our test file
     with patch.object(config, "CORPPA_CONFIG_PATH", new=test_config):
         config_opts = config.get_config()
-        # override value should be used
-        chadwyck_healey_config = config_opts["reference_corpora"]["chadwyck-healey"]
-        assert chadwyck_healey_config["text_dir"] == override_text_dir
-        # default value in the same section that is not specified should be present
+        assert len(config_opts.reference_corpora) == 1
+        ch_config = config_opts.reference_corpora[0]
+        assert ch_config.text_path == Path(override_text_dir)
+
+
+def test_get_config_maximal(tmp_path):
+    # create a test config file with one section and one value
+    test_config = tmp_path / "test.cfg"
+    test_config.write_text("""
+base_dir: data/
+compiled_dataset_dir: found-poems/
+excerpt_data_dir: excerpt-data/
+poem_clusters_path: http://example.com/poem_groups.csv
+reference_corpora:
+    chadwyck-healey:
+    internet_poems:
+    other_poems:
+""")
+    # use patch to override the config path and load our test file
+    with patch.object(config, "CORPPA_CONFIG_PATH", new=test_config):
+        config_opts = config.get_config()
+        assert config_opts.compiled_dataset_dir == Path("data/found-poems")
+        assert config_opts.poem_clusters_path == "http://example.com/poem_groups.csv"
+        assert len(config_opts.reference_corpora) == 3
+        assert [rc.name for rc in config_opts.reference_corpora] == [
+            "chadwyck-healey",
+            "internet_poems",
+            "other_poems",
+        ]
+
+
+## test dataclass config objects
+
+
+class TestCorpusConfig:
+    def test_init_defaults(self):
+        corpus_name = "internet_poems"
+        # specifying corpus name is enough to set defaults for the rest
+        ref_corpus = config.CorpusConfig(name=corpus_name)
+        assert ref_corpus.name == corpus_name
+        assert ref_corpus.base_dir == Path(corpus_name)
+        # default text file suffix
         assert (
-            chadwyck_healey_config["metadata_path"]
-            == config.DEFAULTS["reference_corpora"]["chadwyck-healey"]["metadata_path"]
+            ref_corpus.text_path == ref_corpus.base_dir / f"{corpus_name}_texts.tar.gz"
         )
+        # default metadata suffix
+        assert ref_corpus.metadata_path == ref_corpus.base_dir / f"{corpus_name}.csv"
+
+    def test_init_override(self):
+        corpus_name = "other"
+        # specifying corpus name is enough to set defaults for the rest
+        ref_corpus = config.CorpusConfig(
+            name=corpus_name,
+            base_dir=Path("data/foo"),
+            text_path=Path("my_texts.tar.gz"),
+            metadata_path=Path("data.csv"),
+        )
+        assert ref_corpus.name == corpus_name
+        assert ref_corpus.base_dir == Path("data/foo")
+        # provided paths are now relative to base dir
+        assert ref_corpus.text_path == ref_corpus.base_dir / "my_texts.tar.gz"
+        assert ref_corpus.metadata_path == ref_corpus.base_dir / "data.csv"
+
+        # test absolute path is not changed
+        abs_path = Path("/path/to/my_texts.tar.gz")
+        ref_corpus = config.CorpusConfig(name=corpus_name, text_path=abs_path)
+        assert ref_corpus.text_path == abs_path
+
+    def test_subclass(self):
+        base_dir = Path("ppa_corpus-2026-01-03")
+        ppa_corpus = config.PPACorpusConfig(base_dir=base_dir)
+        assert ppa_corpus.name == "ppa"
+        assert ppa_corpus.base_dir == base_dir
+        # default file names
+        assert ppa_corpus.text_path == base_dir / "ppa_pages.jsonl.gz"
+        assert ppa_corpus.metadata_path == base_dir / "ppa_metadata.csv"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Center for Digital Humanities, Princeton University
+tests / test_config.py  # Copyright (c) 2024-2026, Center for Digital Humanities, Princeton University
 # SPDX-License-Identifier: Apache-2.0
 
 from pathlib import Path
@@ -117,6 +117,33 @@ reference_corpora:
         assert [
             rc.name for rc in config_opts.reference_corpora.values()
         ] == ref_corpora_names
+
+
+## test module-level helpers
+
+
+class TestResolvePath:
+    base = Path("/data/corpora")
+
+    def test_none_returns_none(self):
+        assert config.resolve_path(None, self.base) is None
+
+    def test_string_converted_to_path(self):
+        result = config.resolve_path("subdir/file.txt", self.base)
+        assert isinstance(result, Path)
+        assert result == self.base / "subdir/file.txt"
+
+    def test_absolute_path_unchanged(self):
+        abs_path = Path("/other/location/file.csv")
+        assert config.resolve_path(abs_path, self.base) == abs_path
+
+    def test_relative_path_prefixed_with_base(self):
+        result = config.resolve_path(Path("corpus/texts.tar.gz"), self.base)
+        assert result == self.base / "corpus/texts.tar.gz"
+
+    def test_already_relative_to_base_unchanged(self):
+        already_relative = self.base / "corpus/texts.tar.gz"
+        assert config.resolve_path(already_relative, self.base) == already_relative
 
 
 ## test dataclass config objects

--- a/tests/test_poetry_detection/test_compile_dataset.py
+++ b/tests/test_poetry_detection/test_compile_dataset.py
@@ -217,7 +217,7 @@ def test_run_poem_metadata_step_with_df(mock_load, mock_extract, mock_save, tmp_
     mock_load.assert_not_called()
     mock_extract.assert_called_once_with(input_df)
     mock_save.assert_called_once_with(
-        compile_opts["poem_metadata_file"], mock_extract.return_value
+        compile_opts["poem_metadata_file"], mock_extract.return_value, None
     )
 
 
@@ -234,7 +234,33 @@ def test_run_poem_metadata_step(mock_load, mock_extract, mock_save, tmp_path):
     mock_load.assert_called_once_with(compile_opts)
     mock_extract.assert_not_called()
     mock_save.assert_called_once_with(
-        compile_opts["poem_metadata_file"], mock_load.return_value
+        compile_opts["poem_metadata_file"], mock_load.return_value, None
+    )
+
+
+@patch("corppa.poetry_detection.compile_dataset.pl")
+@patch("corppa.poetry_detection.compile_dataset.save_poem_metadata")
+@patch("corppa.poetry_detection.compile_dataset.extract_page_meta")
+@patch("corppa.poetry_detection.compile_dataset.load_compiled_excerpts")
+def test_run_poem_metadata_step_with_clusters(
+    mock_load, mock_extract, mock_save, mock_pl, tmp_path
+):
+    mock_load.return_value = pl.DataFrame({"id": [1]})
+
+    compile_opts = {
+        "poem_metadata_file": tmp_path / "/out/poem_meta.csv",
+        "source_poem_clusters": "path/to/cluster_ids.csv",
+    }
+
+    run_poem_metadata_step(compile_opts, None)
+
+    mock_load.assert_called_once_with(compile_opts)
+    mock_extract.assert_not_called()
+    mock_pl.read_csv.assert_called_once_with(compile_opts["source_poem_clusters"])
+    mock_save.assert_called_once_with(
+        compile_opts["poem_metadata_file"],
+        mock_load.return_value,
+        mock_pl.read_csv.return_value,
     )
 
 

--- a/tests/test_poetry_detection/test_ref_corpora.py
+++ b/tests/test_poetry_detection/test_ref_corpora.py
@@ -24,21 +24,43 @@ def corppa_test_config(tmp_path):
     # test fixture to create and use a temporary config file
     # uses explicit, non-default paths
     compiled_dataset_dir = tmp_path / "found-poems-data"
-    test_config = tmp_path / "test_config.yml"
     ref_base_dir = tmp_path / "ref-corpora"
-    # use absolute paths for chadwyck-healey to avoid resolution against corpus base_dir
-    test_config.write_text(f"""
-base_dir: {tmp_path}
-compiled_dataset_dir: {compiled_dataset_dir}
-reference_corpora:
-    base_dir: {ref_base_dir}
-    internet_poems:
-    chadwyck-healey:
-    other_poems:
-        metadata_path: http://example.com/other-poems.csv
-    """)
-    with patch.object(config, "CORPPA_CONFIG_PATH", new=test_config):
-        yield test_config
+    ref_base_dir.mkdir()
+
+    ref_corpus_names = ["internet_poems", "chadwyck-healey", "other_poems"]
+
+    ref_corpus_configs = {
+        name: config.CorpusConfig(name=name, relative_dir=ref_base_dir)
+        for name in ref_corpus_names
+    }
+
+    config_opts = config.ConfigOpts(
+        base_dir=tmp_path,
+        compiled_dataset_dir=compiled_dataset_dir,
+        # ppa_corpus=None,
+        reference_corpora=ref_corpus_configs,
+        # excerpt_data_dir=config_values.get("excerpt_data_dir"),
+        # poem_clusters_path=config_values.get("poem_clusters_path"),
+    )
+
+    # validation requires the files to exist, so create them
+    config_opts.reference_corpora["internet_poems"].base_dir.mkdir()
+    config_opts.reference_corpora["internet_poems"].text_path.touch()
+    config_opts.reference_corpora["chadwyck-healey"].base_dir.mkdir()
+    config_opts.reference_corpora["chadwyck-healey"].text_path.touch()
+    config_opts.reference_corpora["chadwyck-healey"].metadata_path.touch()
+    config_opts.reference_corpora["other_poems"].base_dir.mkdir()
+    config_opts.reference_corpora["other_poems"].metadata_path.touch()
+
+    with patch.object(config, "get_config") as mock_get_config:
+        # this patches calls in the current test file
+        mock_get_config.return_value = config_opts
+        # this patches calls in ref_corpora
+        with patch(
+            "corppa.poetry_detection.ref_corpora.get_config"
+        ) as ref_corppa_config:
+            ref_corppa_config.return_value = config_opts
+            yield config_opts
 
 
 class TestBaseReferenceCorpus:
@@ -85,10 +107,10 @@ INTERNETPOEMS_TEXTS = [
 def internetpoems_data_dir(tmp_path, corppa_test_config):
     # test fixture to create internet poems data directory with sample text files
     config_opts = config.get_config()
-    # use the configured text data dir from test config
-    data_dir = config_opts.reference_corpora["internet_poems"].text_path
-
-    data_dir.mkdir(parents=True, exist_ok=True)
+    # update the configured text path in fixture config to be a directory
+    data_dir = config_opts.reference_corpora["internet_poems"].base_dir / "text_files"
+    data_dir.mkdir(exist_ok=True)
+    config_opts.reference_corpora["internet_poems"].text_path = data_dir
     for sample in INTERNETPOEMS_TEXTS:
         text_file = data_dir / f"{sample['id']}.txt"
         text_file.write_text(sample["text"])
@@ -98,16 +120,14 @@ def internetpoems_data_dir(tmp_path, corppa_test_config):
 @pytest.fixture
 def internetpoems_tarball(tmp_path, corppa_test_config):
     # test fixture to create tar.gzip of internet poems data directory with sample text files
-    # should be used with default config
     config_opts = config.get_config()
     internetpoems_data_dir = tmp_path / "internet_poems_texts"
-    internetpoems_data_dir.mkdir(parents=True, exist_ok=True)
+    internetpoems_data_dir.mkdir(exist_ok=True)
     for sample in INTERNETPOEMS_TEXTS:
         text_file = internetpoems_data_dir / f"{sample['id']}.txt"
         text_file.write_text(sample["text"])
 
     tarfile_path = config_opts.reference_corpora["internet_poems"].text_path
-    tarfile_path.parent.mkdir(parents=True, exist_ok=True)
 
     with tarfile.open(tarfile_path, "w:gz") as tar:
         for text_file in internetpoems_data_dir.glob("*.txt"):
@@ -198,21 +218,6 @@ class TestInternetPoems:
         assert text_data[0]["poem_id"] == INTERNETPOEMS_TEXTS[0]["id"]
         assert text_data[0]["text"] == INTERNETPOEMS_TEXTS[0]["text"]
 
-    def test_get_text_unsupported(self, tmp_path):
-        # unsupported file type raises NotImplementedError from get_text_corpus
-        zipfile = tmp_path / "internet_poems.zip"
-        zipfile.touch()
-        corpus_config = config.CorpusConfig(
-            name="internet_poems",
-            base_dir=tmp_path,
-            text_path=zipfile,
-        )
-        internet_poems = InternetPoems(corpus_config)
-        with pytest.raises(
-            NotImplementedError, match="only supported for tar.gz and directories"
-        ):
-            list(internet_poems.get_text_corpus())
-
     def test_get_text_corpus(
         self,
         tmp_path,
@@ -235,10 +240,13 @@ def chadwyck_healey_csv(tmp_path, corppa_test_config):
     "fixture to create a test version of the chadwyck-healey metadata csv file"
     config_opts = config.get_config()
     ch_config = config_opts.reference_corpora[ChadwyckHealey.corpus_id]
-    data_dir = ch_config.text_path
+    # unlink fixture file and make text path a directory
+    ch_config.text_path.unlink()
+    data_dir = ch_config.base_dir / "text_files"
+    data_dir.mkdir(exist_ok=True)
+    ch_config.text_path = data_dir
     ch_meta_csv = ch_config.metadata_path
 
-    data_dir.mkdir(parents=True, exist_ok=True)
     ch_meta_csv.write_text("""id,author_lastname,author_firstname,author_birth,author_death,author_period,transl_lastname,transl_firstname,transl_birth,transl_death,title_id,title_main,title_sub,edition_id,edition_text,period,genre,rhymes
 Z300475611,Robinson,Mary,1758,1800,,,,,,Z300475611,THE CAVERN OF WOE.,,Z000475579,The Poetical Works (1806),Later Eighteenth-Century 1750-1799,,y""")
     return ch_meta_csv

--- a/tests/test_poetry_detection/test_ref_corpora.py
+++ b/tests/test_poetry_detection/test_ref_corpora.py
@@ -27,19 +27,21 @@ def corppa_test_config(tmp_path):
     compiled_dataset_dir = tmp_path / "found-poems-data"
     test_config = tmp_path / "test_config.yml"
     base_dir = tmp_path / "ref-corpora"
+    # use absolute paths for chadwyck-healey to avoid resolution against corpus base_dir
+    ch_text_path = base_dir / "ch"
+    ch_metadata_path = base_dir / "ch" / "chadwyck-healey.csv"
     test_config.write_text(f"""
-    # local path to compiled poem dataset files
-    compiled_dataset:    
-        output_data_dir : {compiled_dataset_dir}
-    reference_corpora:
-        base_dir: {base_dir}
-        internet_poems:
-            text_path: {base_dir / "internet_poems2"}
-        chadwyck-healey:
-            text_path: "ch"
-            metadata_path: "ch/chadwyck-healey.csv"
-        other:
-            metadata_path: http://example.com/other-poems.csv
+base_dir: {tmp_path}
+compiled_dataset_dir: {compiled_dataset_dir}
+reference_corpora:
+    base_dir: {base_dir}
+    internet_poems:
+        text_path: {base_dir / "internet_poems2"}
+    chadwyck-healey:
+        text_path: {ch_text_path}
+        metadata_path: {ch_metadata_path}
+    other_poems:
+        metadata_path: http://example.com/other-poems.csv
     """)
     with patch.object(config, "CORPPA_CONFIG_PATH", new=test_config):
         yield test_config
@@ -52,13 +54,13 @@ def corppa_test_config_defaults(tmp_path):
     compiled_dataset_dir = tmp_path / "found-poems-data"
     base_dir = tmp_path / "ref-corpora"
     test_config.write_text(f"""
-    # local path to compiled poem dataset files
-    compiled_dataset:    
-        output_data_dir : {compiled_dataset_dir}
-    reference_corpora:
-        base_dir: {base_dir}
-        other:
-            metadata_path: http://example.com/other-poems.csv
+base_dir: {tmp_path}
+compiled_dataset_dir: {compiled_dataset_dir}
+reference_corpora:
+    base_dir: {base_dir}
+    internet_poems:
+    other_poems:
+        metadata_path: http://example.com/other-poems.csv
     """)
     with patch.object(config, "CORPPA_CONFIG_PATH", new=test_config):
         yield test_config
@@ -71,52 +73,6 @@ class TestBaseReferenceCorpus:
 
         with pytest.raises(NotImplementedError):
             BaseReferenceCorpus().get_text_corpus()
-
-    @patch("corppa.poetry_detection.ref_corpora.get_config")
-    def test_get_config_error(self, mock_get_config):
-        # reference_corpora not set
-        mock_get_config.return_value = {}
-        with pytest.raises(
-            ValueError,
-            match="Configuration error: required section 'reference_corpora' not found",
-        ):
-            BaseReferenceCorpus().get_config_opts()
-
-        # reference_corpora section but no base dir
-        mock_get_config.return_value = {"reference_corpora": {}}
-        with pytest.raises(
-            ValueError,
-            match="Configuration error: required 'reference_corpora.base_dir' not found",
-        ):
-            BaseReferenceCorpus().get_config_opts()
-
-        # reference_corpora path relative but no ingredients dir
-        mock_get_config.return_value = {
-            "reference_corpora": {"base_dir": "ref-corpora"}
-        }
-        with pytest.raises(
-            ValueError,
-            match="Configuration error: 'reference_corpora.base_dir' is relative but 'data_ingredients_dir' is not configured",
-        ):
-            BaseReferenceCorpus().get_config_opts()
-
-    @patch("corppa.poetry_detection.ref_corpora.get_config")
-    def test_get_config_relative_dir(self, mock_get_config):
-        # reference_corpora path should be made relative to ingredients dir
-        ingredients_dir = "/tigerdata/cdh/prosody/ingredients"
-        ref_corpora_dir = "ref-corpora"
-        mock_get_config.return_value = {
-            "data_ingredients_dir": ingredients_dir,
-            "reference_corpora": {"base_dir": ref_corpora_dir},
-        }
-
-        test_ref_corpus = BaseReferenceCorpus()
-        test_ref_corpus.corpus_id = "test"
-        config_opts = test_ref_corpus.get_config_opts()
-        assert isinstance(config_opts["base_dir"], pathlib.Path)
-        assert (
-            config_opts["base_dir"] == pathlib.Path(ingredients_dir) / ref_corpora_dir
-        )
 
     def test_calculate_poem_length(self):
         # Test single line text
@@ -155,9 +111,7 @@ def internetpoems_data_dir(tmp_path, corppa_test_config):
     # test fixture to create internet poems data directory with sample text files
     config_opts = config.get_config()
     # use the configured text data dir from test config
-    data_dir = pathlib.Path(
-        config_opts["reference_corpora"]["internet_poems"]["text_path"]
-    )
+    data_dir = config_opts.reference_corpora["internet_poems"].text_path
 
     data_dir.mkdir(parents=True, exist_ok=True)
     for sample in INTERNETPOEMS_TEXTS:
@@ -177,9 +131,7 @@ def internetpoems_tarball(tmp_path, corppa_test_config_defaults):
         text_file = internetpoems_data_dir / f"{sample['id']}.txt"
         text_file.write_text(sample["text"])
 
-    tarfile_name = config_opts["reference_corpora"]["internet_poems"]["text_path"]
-    base_dir = pathlib.Path(config_opts["reference_corpora"]["base_dir"])
-    tarfile_path = base_dir / tarfile_name
+    tarfile_path = config_opts.reference_corpora["internet_poems"].text_path
     tarfile_path.parent.mkdir(parents=True, exist_ok=True)
 
     with tarfile.open(tarfile_path, "w:gz") as tar:
@@ -190,45 +142,18 @@ def internetpoems_tarball(tmp_path, corppa_test_config_defaults):
 
 
 class TestInternetPoems:
-    def test_init(self, tmp_path, corppa_test_config):
-        # path in test config doesn't exist
-        with pytest.raises(ValueError, match="Configuration error:.* does not exist"):
-            InternetPoems()
-
+    def test_init(self, corppa_test_config):
         config_opts = config.get_config()
-        # expected data_dir
-        expected_data_dir = pathlib.Path(
-            config_opts["reference_corpora"]["internet_poems"]["text_path"]
-        )
+        ip_config = config_opts.reference_corpora["internet_poems"]
+        internet_poems = InternetPoems(ip_config)
+        assert internet_poems.config == ip_config
+        assert isinstance(internet_poems.config, config.CorpusConfig)
 
-        # init should succeed when directory exists
-        expected_data_dir.mkdir(parents=True)
-        internet_poems = InternetPoems()
-        assert isinstance(internet_poems.text_path, pathlib.Path)
-        assert internet_poems.text_path == expected_data_dir
-
-        # error if it is not a directory : remove dir and create a regular file
-        expected_data_dir.rmdir()
-        expected_data_dir.touch()
-        with pytest.raises(
-            ValueError, match="Configuration error:.* is not a directory"
-        ):
-            InternetPoems()
-
-    @patch("corppa.poetry_detection.ref_corpora.pathlib")
-    def test_get_config(self, mock_pathlib, tmp_path, corppa_test_config):
-        config_opts = InternetPoems().get_config_opts()
-        # should pass in reference corpus base directory
-        assert "base_dir" in config_opts
-        # should include ref_corpus specific options, where are in the test config
-        assert "text_path" in config_opts
-
-    @patch.object(InternetPoems, "get_config_opts")
     def test_get_metadata_df(
-        self, mock_get_config_opts, tmp_path, corppa_test_config, internetpoems_data_dir
+        self, tmp_path, corppa_test_config, internetpoems_data_dir
     ):
-        mock_get_config_opts.return_value = {"text_path": str(internetpoems_data_dir)}
-        internet_poems = InternetPoems()
+        config_opts = config.get_config()
+        internet_poems = InternetPoems(config_opts.reference_corpora["internet_poems"])
         meta_df = internet_poems.get_metadata_df(poem_length=True)
         assert isinstance(meta_df, pl.DataFrame)
         assert meta_df.schema == METADATA_SCHEMA
@@ -244,13 +169,12 @@ class TestInternetPoems:
         assert meta_row["num_words"] == 9
         assert meta_row["char_len"] == len(INTERNETPOEMS_TEXTS[0]["text"])
 
-    @patch.object(InternetPoems, "get_config_opts")
     def test_get_metadata_df_no_poem_length(
-        self, mock_get_config_opts, tmp_path, corppa_test_config, internetpoems_data_dir
+        self, tmp_path, corppa_test_config, internetpoems_data_dir
     ):
         # Test that poem_length=False sets length fields to null
-        mock_get_config_opts.return_value = {"text_path": str(internetpoems_data_dir)}
-        internet_poems = InternetPoems()
+        config_opts = config.get_config()
+        internet_poems = InternetPoems(config_opts.reference_corpora["internet_poems"])
         meta_df = internet_poems.get_metadata_df(poem_length=False)
         assert isinstance(meta_df, pl.DataFrame)
         # Length fields should be present but null
@@ -269,7 +193,8 @@ class TestInternetPoems:
         corppa_test_config_defaults,
         internetpoems_tarball,
     ):
-        internet_poems = InternetPoems()
+        config_opts = config.get_config()
+        internet_poems = InternetPoems(config_opts.reference_corpora["internet_poems"])
         meta_df = internet_poems.get_metadata_df()
         assert isinstance(meta_df, pl.DataFrame)
         assert meta_df.schema == METADATA_SCHEMA
@@ -287,8 +212,8 @@ class TestInternetPoems:
         corppa_test_config_defaults,
         internetpoems_tarball,
     ):
-        internet_poems = InternetPoems()
-        # with pytest.raises(NotImplementedError, match="not supported for tar.gz"):
+        config_opts = config.get_config()
+        internet_poems = InternetPoems(config_opts.reference_corpora["internet_poems"])
         # returns a generator; use list to get to actually run
         # convert to list, sort to ensure order matches fixture data
         text_data = sorted(
@@ -298,50 +223,29 @@ class TestInternetPoems:
         assert text_data[0]["poem_id"] == INTERNETPOEMS_TEXTS[0]["id"]
         assert text_data[0]["text"] == INTERNETPOEMS_TEXTS[0]["text"]
 
-    @patch.object(InternetPoems, "get_config_opts")
-    def test_get_text_unsupported(
-        self,
-        mock_get_config_opts,
-        tmp_path,
-        corppa_test_config_defaults,
-    ):
+    def test_get_text_unsupported(self, tmp_path):
+        # unsupported file type raises NotImplementedError from get_text_corpus
         zipfile = tmp_path / "internet_poems.zip"
         zipfile.touch()
-        mock_get_config_opts.return_value = {
-            "text_path": zipfile,
-            "base_dir": tmp_path / "ref-corpora",
-        }
-        with pytest.raises(ValueError, match=".*not a directory or a tar.gz"):
-            # checks configuration on init
-            InternetPoems()
-
-    def get_text_corpus_unsupported(
-        self, mock_get_config_opts, tmp_path, corppa_test_config_defaults
-    ):
-        zipfile = tmp_path / "internet_poems.zip"
-        zipfile.touch()
-        # init normally to by pass the check path type check
-        internet_poems = InternetPoems()
-        # patch in our zip file
-        internet_poems.text_path = zipfile
+        corpus_config = config.CorpusConfig(
+            name="internet_poems",
+            base_dir=tmp_path,
+            text_path=zipfile,
+        )
+        internet_poems = InternetPoems(corpus_config)
         with pytest.raises(
             NotImplementedError, match="only supported for tar.gz and directories"
         ):
-            internet_poems.get_text_corpus()
+            list(internet_poems.get_text_corpus())
 
-    @patch.object(InternetPoems, "get_config_opts")
     def test_get_text_corpus(
         self,
-        mock_get_config_opts,
         tmp_path,
         corppa_test_config,
         internetpoems_data_dir,
     ):
-        mock_get_config_opts.return_value = {
-            "text_path": str(internetpoems_data_dir),
-            "base_dir": tmp_path / "ref-corpora",
-        }
-        internet_poems = InternetPoems()
+        config_opts = config.get_config()
+        internet_poems = InternetPoems(config_opts.reference_corpora["internet_poems"])
         text_data = internet_poems.get_text_corpus()
         assert isinstance(text_data, Generator)
         # turn the generator into a list; sort by id so order matches input
@@ -354,20 +258,10 @@ class TestInternetPoems:
 @pytest.fixture
 def chadwyck_healey_csv(tmp_path, corppa_test_config):
     "fixture to create a test version of the chadwyck-healey metadata csv file"
-    # test fixture to create chadwyck-healey data directory with sample metadata csv
-
     config_opts = config.get_config()
-    # use the configured data paths from test config
-    base_dir = pathlib.Path(config_opts["reference_corpora"]["base_dir"])
-    override_opts = config_opts["reference_corpora"][ChadwyckHealey.corpus_id]
-    data_dir = pathlib.Path(override_opts["text_path"])
-    ch_meta_csv = pathlib.Path(override_opts["metadata_path"])
-
-    # in either case, make relative to base dir if not absolute
-    if not data_dir.is_absolute():
-        data_dir = base_dir / data_dir
-    if not ch_meta_csv.is_absolute():
-        ch_meta_csv = base_dir / ch_meta_csv
+    ch_config = config_opts.reference_corpora[ChadwyckHealey.corpus_id]
+    data_dir = ch_config.text_path
+    ch_meta_csv = ch_config.metadata_path
 
     data_dir.mkdir(parents=True, exist_ok=True)
     ch_meta_csv.write_text("""id,author_lastname,author_firstname,author_birth,author_death,author_period,transl_lastname,transl_firstname,transl_birth,transl_death,title_id,title_main,title_sub,edition_id,edition_text,period,genre,rhymes
@@ -376,16 +270,17 @@ Z300475611,Robinson,Mary,1758,1800,,,,,,Z300475611,THE CAVERN OF WOE.,,Z00047557
 
 
 class TestChadwyckHealey:
-    def test_init(self, tmp_path, corppa_test_config, chadwyck_healey_csv):
-        # configured metadata file doesn't exist
-        chadwyck_healey_csv.unlink()
-        with pytest.raises(
-            ValueError, match="Configuration error:.* metadata .* does not exist"
-        ):
-            ChadwyckHealey()
+    def test_init(self, corppa_test_config, chadwyck_healey_csv):
+        config_opts = config.get_config()
+        ch = ChadwyckHealey(config_opts.reference_corpora[ChadwyckHealey.corpus_id])
+        assert isinstance(ch.config, config.CorpusConfig)
+        assert ch.config.metadata_path == chadwyck_healey_csv
 
     def test_get_metadata_df(self, tmp_path, corppa_test_config, chadwyck_healey_csv):
-        chadwyck_healey = ChadwyckHealey()
+        config_opts = config.get_config()
+        chadwyck_healey = ChadwyckHealey(
+            config_opts.reference_corpora[ChadwyckHealey.corpus_id]
+        )
         meta_df = chadwyck_healey.get_metadata_df()
         assert isinstance(meta_df, pl.DataFrame)
         # schema is a subset because we don't include poem lengths
@@ -403,8 +298,11 @@ class TestChadwyckHealey:
         self, tmp_path, corppa_test_config, chadwyck_healey_csv
     ):
         # Create a text file for the poem to test poem length calculation
-        chadwyck_healey = ChadwyckHealey()
-        text_dir = chadwyck_healey.text_path
+        config_opts = config.get_config()
+        chadwyck_healey = ChadwyckHealey(
+            config_opts.reference_corpora[ChadwyckHealey.corpus_id]
+        )
+        text_dir = chadwyck_healey.config.text_path
         # three lines, eight words
         text_content = "Line one here\nLine two here\nLine three"
         text_file = text_dir / "Z300475611.txt"
@@ -453,7 +351,8 @@ class TestOtherPoems:
         self, mock_pl_read_csv, corppa_test_config, otherpoems_metadata_df
     ):
         mock_pl_read_csv.return_value = otherpoems_metadata_df
-        opoems = OtherPoems()
+        config_opts = config.get_config()
+        opoems = OtherPoems(config_opts.reference_corpora["other_poems"])
         meta_df = opoems.get_metadata_df()
         assert isinstance(meta_df, pl.DataFrame)
         # schema is a subset because we don't include poem lengths
@@ -467,28 +366,15 @@ class TestOtherPoems:
         assert meta_row["ref_corpus"] == opoems.corpus_id
 
         mock_pl_read_csv.assert_called_with(
-            opoems.metadata_path, schema=METADATA_SCHEMA
+            opoems.config.metadata_path, schema=METADATA_SCHEMA
         )
-
-    @patch.object(OtherPoems, "get_config_opts")
-    def test_config_error(self, mock_get_config_opts):
-        mock_get_config_opts.return_value = {}
-        with pytest.raises(
-            ValueError, match="Configuration error:.* 'metadata_path' is not set"
-        ):
-            OtherPoems()
 
 
 # because this method instantiates the ref_corpus objects,
 # data directories must pass validation checks
 
 
-def test_all_corpora(
-    corppa_test_config,
-    internetpoems_data_dir,
-    chadwyck_healey_csv,
-    otherpoems_metadata_df,
-):
+def test_all_corpora(corppa_test_config):
     all_ref_corpora = all_corpora()
     assert all(
         isinstance(ref_corpus, BaseReferenceCorpus) for ref_corpus in all_ref_corpora
@@ -498,12 +384,7 @@ def test_all_corpora(
     assert corpus_classes == [InternetPoems, ChadwyckHealey, OtherPoems]
 
 
-def test_fulltext_corpora(
-    corppa_test_config,
-    internetpoems_data_dir,
-    chadwyck_healey_csv,
-    otherpoems_metadata_df,
-):
+def test_fulltext_corpora(corppa_test_config):
     fulltext_ref_corpora = fulltext_corpora()
     assert all(
         isinstance(ref_corpus, BaseReferenceCorpus)
@@ -554,7 +435,6 @@ def test_save_poem_metadata(
     otherpoems_metadata_df,
 ):
     # data fixtures should ensure that all the expected directories exist
-    # mock_get_config_opts.return_value = {"text_path": str(internetpoems_data_dir)}
 
     # add corpus id to other poems data frame and patch it to be returned
     otherpoems_metadata_df = otherpoems_metadata_df.with_columns(
@@ -612,7 +492,7 @@ def test_save_poem_metadata_with_cluster_ids(
         assert output_file.exists()
         # check output
         df = pl.read_csv(output_file)
-        # should still have all rowq
+        # should still have all rows
         assert df.height == 6
         # 2 poems should have cluster id
         assert "cluster_id" in df.columns

--- a/tests/test_poetry_detection/test_ref_corpora.py
+++ b/tests/test_poetry_detection/test_ref_corpora.py
@@ -182,6 +182,43 @@ class TestInternetPoems:
             == 0
         )
 
+    def test_get_metadata_df_csv_and_poem_length(
+        self, tmp_path, corppa_test_config, internetpoems_data_dir, capsys
+    ):
+        # test case where we load metadata from CSV and add poem length info
+
+        config_opts = config.get_config()
+        ipoem_cfg = config_opts.reference_corpora["internet_poems"]
+        # create a very simple metadata file based on fixture dictionary ids
+        ip_meta_csv = ipoem_cfg.metadata_path
+        # split id into poem id, author, title
+        csv_rows = [
+            (poem["id"], poem["id"].split("_")[0], poem["id"].split("_")[1])
+            for poem in INTERNETPOEMS_TEXTS
+        ]
+        # combine header row and one row for each poem, then write out to the meta path
+        csv_text = "poem_id,author,title\n" + "\n".join(
+            ",".join(row) for row in csv_rows
+        )
+        ip_meta_csv.write_text(csv_text)
+
+        internet_poems = InternetPoems(ipoem_cfg)
+        meta_df = internet_poems.get_metadata_df(poem_length=True)
+        assert isinstance(meta_df, pl.DataFrame)
+        # Length fields should be present but null
+        assert "num_lines" in meta_df.columns
+        assert "num_words" in meta_df.columns
+        assert "char_len" in meta_df.columns
+
+        # get the first row as a dict; sort by id so order matches input
+        meta_row = meta_df.sort("poem_id").row(0, named=True)
+        assert meta_row["poem_id"] == INTERNETPOEMS_TEXTS[0]["id"]
+        assert meta_row["ref_corpus"] == internet_poems.corpus_id
+        # check poem length calculations (non-blank lines, word count, char length)
+        assert meta_row["num_lines"] == 1
+        assert meta_row["num_words"] == 9
+        assert meta_row["char_len"] == len(INTERNETPOEMS_TEXTS[0]["text"])
+
     def test_get_metadata_df_tarball(
         self,
         tmp_path,

--- a/tests/test_poetry_detection/test_ref_corpora.py
+++ b/tests/test_poetry_detection/test_ref_corpora.py
@@ -1,4 +1,3 @@
-import pathlib
 import tarfile
 from collections.abc import Generator
 from unittest.mock import patch
@@ -26,39 +25,15 @@ def corppa_test_config(tmp_path):
     # uses explicit, non-default paths
     compiled_dataset_dir = tmp_path / "found-poems-data"
     test_config = tmp_path / "test_config.yml"
-    base_dir = tmp_path / "ref-corpora"
+    ref_base_dir = tmp_path / "ref-corpora"
     # use absolute paths for chadwyck-healey to avoid resolution against corpus base_dir
-    ch_text_path = base_dir / "ch"
-    ch_metadata_path = base_dir / "ch" / "chadwyck-healey.csv"
     test_config.write_text(f"""
 base_dir: {tmp_path}
 compiled_dataset_dir: {compiled_dataset_dir}
 reference_corpora:
-    base_dir: {base_dir}
+    base_dir: {ref_base_dir}
     internet_poems:
-        text_path: {base_dir / "internet_poems2"}
     chadwyck-healey:
-        text_path: {ch_text_path}
-        metadata_path: {ch_metadata_path}
-    other_poems:
-        metadata_path: http://example.com/other-poems.csv
-    """)
-    with patch.object(config, "CORPPA_CONFIG_PATH", new=test_config):
-        yield test_config
-
-
-@pytest.fixture
-def corppa_test_config_defaults(tmp_path):
-    # test fixture with a minimal reference corpus config file
-    test_config = tmp_path / "test_config.yml"
-    compiled_dataset_dir = tmp_path / "found-poems-data"
-    base_dir = tmp_path / "ref-corpora"
-    test_config.write_text(f"""
-base_dir: {tmp_path}
-compiled_dataset_dir: {compiled_dataset_dir}
-reference_corpora:
-    base_dir: {base_dir}
-    internet_poems:
     other_poems:
         metadata_path: http://example.com/other-poems.csv
     """)
@@ -121,7 +96,7 @@ def internetpoems_data_dir(tmp_path, corppa_test_config):
 
 
 @pytest.fixture
-def internetpoems_tarball(tmp_path, corppa_test_config_defaults):
+def internetpoems_tarball(tmp_path, corppa_test_config):
     # test fixture to create tar.gzip of internet poems data directory with sample text files
     # should be used with default config
     config_opts = config.get_config()
@@ -190,7 +165,7 @@ class TestInternetPoems:
     def test_get_metadata_df_tarball(
         self,
         tmp_path,
-        corppa_test_config_defaults,
+        corppa_test_config,
         internetpoems_tarball,
     ):
         config_opts = config.get_config()
@@ -209,7 +184,7 @@ class TestInternetPoems:
     def test_get_text_corpus_tarball(
         self,
         tmp_path,
-        corppa_test_config_defaults,
+        corppa_test_config,
         internetpoems_tarball,
     ):
         config_opts = config.get_config()

--- a/tests/test_poetry_detection/test_ref_corpora.py
+++ b/tests/test_poetry_detection/test_ref_corpora.py
@@ -580,6 +580,52 @@ def test_save_poem_metadata(
         assert "Replacing" in captured.out
 
 
+def test_save_poem_metadata_with_cluster_ids(
+    tmp_path,
+    capsys,
+    corppa_test_config,
+    internetpoems_data_dir,
+    otherpoems_metadata_df,
+    chadwyck_healey_csv,
+):
+    # test compiling in poem cluster ids;
+    # confirm left join works as desired, adding clusters or nulls
+    # for poems that do not have a cluster id
+
+    # made up cluster for testing purposes, with ids from fixtures
+    cluster_id_df = pl.DataFrame(
+        data={
+            "poem_id": ["Robert-Burns_Mary", "Z300475611"],
+            "cluster_id": ["mary", "mary"],
+        }
+    )
+    # add corpus id to other poems data frame and patch it to be returned
+    otherpoems_metadata_df = otherpoems_metadata_df.with_columns(
+        ref_corpus=pl.lit(OtherPoems.corpus_id)
+    )
+    with patch.object(
+        OtherPoems, "get_metadata_df", return_value=otherpoems_metadata_df
+    ):
+        # create a path reference for the file we want to create
+        output_file = tmp_path / "poem_meta.csv"
+        save_poem_metadata(output_file, poem_clusters_df=cluster_id_df)
+        assert output_file.exists()
+        # check output
+        df = pl.read_csv(output_file)
+        # should still have all rowq
+        assert df.height == 6
+        # 2 poems should have cluster id
+        assert "cluster_id" in df.columns
+        assert df.filter(pl.col.cluster_id.is_not_null()).height == 2
+        # others should be null
+        assert df.filter(pl.col.cluster_id.is_null()).height == 4
+
+        captured = capsys.readouterr()
+        # check output reporting on cluster ids
+        assert "2 poems with cluster ids" in captured.out
+        assert "(1 unique cluster)" in captured.out
+
+
 def test_save_poem_metadata_with_excerpts(
     tmp_path,
     capsys,

--- a/tests/test_poetry_detection/test_ref_corpora.py
+++ b/tests/test_poetry_detection/test_ref_corpora.py
@@ -472,7 +472,7 @@ def test_save_poem_metadata_with_cluster_ids(
         # create a path reference for the file we want to create
         output_file = tmp_path / "poem_meta.csv"
         save_poem_metadata(output_file, poem_clusters_df=cluster_id_df)
-        assert output_file.exists()
+        assert output_file.is_file()
         # check output
         df = pl.read_csv(output_file)
         # should still have all rows


### PR DESCRIPTION
**Associated Issue(s):** #273 (related but does not fully resolve); resolves #258

### Changes in this PR

- ✅ Support poem cluster ids when compiling poem metadata (previously reviewed)
- Overhaul configuration code to simplify and consolidate logic
    - Updated sample config file to new structure
    - Remove dict munging; using simple dataclasses for config objects (top level and corpus config)
    - Updated reference corpora and compilation code to use the new config objects
- update `run_passim` script to use the same defaults in `main` args and `run_passim` method

### Notes

- As you review, please be clear about anything you think must be correct before merging and releasing the current version. We can make issues to track future refinements or add it to the [1.0 dataset todos/wishlist doc](https://docs.google.com/document/d/1784Tu4X1xEpHE8BgLdN5jajiHL4SzfXesXZIM9z8_u4/edit?tab=t.0) (- I think the code and data work are related).
- All files for v0.5 found poems dataset are on TigerData: prosody/poetry-detection/2026-05-foundpoems-v0.5/   - this includes a sample config file with instructions for the files to copy and how to configure to run locally

### Reviewer Checklist

- [x] Review code and tests to check the logic makes sense and does what we want
- [x] Review files and organization on TigerData
- [x] Test running locally with the files & configuration copied from TigerData : `corppa-compile-dataset` ; output should match the compiled dataset on TigerData
